### PR TITLE
[FIX] - rest route warning issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,10 @@ Privacy is our utmost priority, and we designed ThriveDesk in a way that aligned
 - Easy setup: Setup your Shared Inbox in less than a minute. 
 
 == Changelog ==
+= 0.9.2 =
+- Fixed rest route warning issue
+- Improved rest route api call
+
 = 0.9.1 =
 - Fixed database migration bug
 

--- a/src/RestRoute.php
+++ b/src/RestRoute.php
@@ -41,8 +41,11 @@ class RestRoute
     public function td_routes()
     {
         register_rest_route('thrivedesk/v1', '/conversations/contact/(?P<id>\d+)', array(
-            'methods'  => 'get',
-            'callback' => array($this, 'get_thrivedesk_conversations')
+            'methods'             => 'get',
+            'callback'            => array($this, 'get_thrivedesk_conversations'),
+            'permission_callback' => function () {
+                return current_user_can('manage_options');
+            }
         ));
     }
 

--- a/thrivedesk.php
+++ b/thrivedesk.php
@@ -5,7 +5,7 @@
  * Description:         Live Chat, Chatbots, Knowledge Base & Helpdesk for WordPress
  * Plugin URI:          https://www.thrivedesk.com/?utm_source=wp-plugins&utm_campaign=plugin-uri&utm_medium=wp-dash
  * Tags:                thrivedesk,
- * Version:             0.9.1
+ * Version:             0.9.2
  * Author:              ThriveDesk
  * Author URI:          https://profiles.wordpress.org/thrivedesk/
  * Text Domain:         thrivedesk
@@ -44,7 +44,7 @@ final class ThriveDesk
      *
      * @var string
      */
-    public $version = '0.9.1';
+    public $version = '0.9.2';
 
     /**
      * The single instance of this class


### PR DESCRIPTION
In WordPress 5.5, a change was made to how REST routes are registered and now required a `permission_callback`.

The reason you may see it the notice on one site and not all is that notices only appear when WordPress is run in DEBUG mode, confirm by checking the value of `wp-config.php` for
```php
    define( 'WP_DEBUG', true );
```

The issue is fixed now by providing a `permission_callback`.