### PR TITLE
[FIX] - Swapped Autonami lists and tags info

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,9 @@ Privacy is our utmost priority, and we designed ThriveDesk in a way that aligned
 - Easy setup: Setup your Shared Inbox in less than a minute. 
 
 == Changelog ==
+= 0.9.4 =
+- Fixed swapped Autonami lists and tags info
+
 = 0.9.3 =
 - Added EDD customer info
 - Fixed code formatting

--- a/src/Plugins/Autonami.php
+++ b/src/Plugins/Autonami.php
@@ -243,8 +243,8 @@ final class Autonami extends Plugin
             'contact_type'   => $this->customer->get_type(),
             'date_of_birth'  => $date_of_birth ? date('d M Y', strtotime($date_of_birth)) : '',
             'status'         => $this->customer->get_status(),
-            'tags'           => $lists,
-            'lists'          => $tags,
+            'lists'          => $lists,
+            'tags'           => $tags,
         ];
     }
 

--- a/thrivedesk.php
+++ b/thrivedesk.php
@@ -5,7 +5,7 @@
  * Description:         Live Chat, Chatbots, Knowledge Base & Helpdesk for WordPress
  * Plugin URI:          https://www.thrivedesk.com/?utm_source=wp-plugins&utm_campaign=plugin-uri&utm_medium=wp-dash
  * Tags:                thrivedesk,
- * Version:             0.9.3
+ * Version:             0.9.4
  * Author:              ThriveDesk
  * Author URI:          https://profiles.wordpress.org/thrivedesk/
  * Text Domain:         thrivedesk
@@ -44,7 +44,7 @@ final class ThriveDesk
      *
      * @var string
      */
-    public $version = '0.9.3';
+    public $version = '0.9.4';
 
     /**
      * The single instance of this class


### PR DESCRIPTION
ThriveDesk autonami integration showing tags as list and lists as tags. This issue in on WordPress site where I've returned them (lists as tags and vice versa) 