### PR TITLE
Fix/woocommerce total count issue

### DIFF
--- a/src/Plugins/WooCommerce.php
+++ b/src/Plugins/WooCommerce.php
@@ -169,7 +169,7 @@ final class WooCommerce extends Plugin {
 			foreach ( $customer_orders as $order ) {
 				array_push( $this->orders, [
 					'order_id'        => $order->get_id(),
-					'amount'          => $this->get_formated_amount( (float) $order->get_total() ),
+					'amount'          => (float) $order->get_total(),
 					'amount_formated' => $this->get_formated_amount( $order->get_total() ),
 					'date'            => date( 'd M Y', strtotime( $order->get_date_created() ) ),
 					'order_status'    => ucfirst( $order->get_status() ),

--- a/src/Plugins/WooCommerce.php
+++ b/src/Plugins/WooCommerce.php
@@ -176,7 +176,7 @@ final class WooCommerce extends Plugin {
 					'shipping'        => $this->shipping_param ? $this->get_shipping_details( $order ) : [],
 					'downloads'       => $this->get_order_items( $order ),
 					'order_url'       => method_exists( $order,
-						'get_edit_order_url' ) ? $order->get_edit_order_url() : '#',
+					'get_edit_order_url' ) ? $order->get_edit_order_url() : '#',
 					'coupon'          => $order->get_coupon_codes() ?? null,
 
 				] );


### PR DESCRIPTION
Data was showing default value. Now it's fixed.
![image](https://github.com/thrivedesk/wp-thrivedesk/assets/44565867/8043bb50-424b-4c4a-a31b-1e3a1d9cab74)

## Related PR link
https://github.com/thrivedesk/app-frontend/pull/835