### PR TITLE
Feat: Assistant visibility controlling based on routes

### DIFF
--- a/includes/views/partials/settings.php
+++ b/includes/views/partials/settings.php
@@ -37,6 +37,17 @@ $td_user_account_pages = array(
     'woocommerce' => 'Add to WooCommerce'
 );
 
+// Fetch all published pages
+$pages = get_pages(array(
+    'post_status' => 'publish',
+));
+
+// Collect routes into an array
+$routes = array();
+
+foreach ($pages as $page) {
+    $routes[$page->ID] = get_permalink($page->ID);
+}
 
 // Get current user
 $current_user = wp_get_current_user();
@@ -75,6 +86,28 @@ $current_user = wp_get_current_user();
             <?php endif; ?>
         </div>
     </div>
+
+    <!-- assistant settings -->
+    <div class="space-y-1">
+        <div class="td-card-heading">
+            <div class="text-base font-bold"><?php _e('Select Routes', 'thrivedesk'); ?></div>
+            <p><?php _e('Choose the routes where the assistant should not be visible.', 'thrivedesk'); ?></p>
+        </div>
+        <div class="td-card">
+            <div class="space-y-2">
+                <label class="font-medium text-black text-sm"><?php _e('Exclude Routes', 'thrivedesk'); ?></label>
+                <select name="td_excluded_routes[]" id="td-excluded-routes" class="mt-1 bg-gray-50 border border-gray-300 rounded px-2 py-1 w-full max-w-full">
+                    <?php foreach ($routes as $page_id => $route) : ?>
+                        <option value="<?php echo $route; ?>" <?php echo ($td_helpdesk_selected_option['td_assistant_route_list'] == $route) ? 'selected' : ''; ?>>
+                            <?php echo $route; ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+        </div>
+    </div>
+
+    <!-- end assistant settings -->
 
     <?php if ($wppostsync && $wppostsync->get_plugin_data('connected')) : ?>
         <!-- WP Post Sync  -->

--- a/includes/views/partials/settings.php
+++ b/includes/views/partials/settings.php
@@ -58,9 +58,9 @@ $current_user = wp_get_current_user();
     <div class="space-y-1">
         <div class="td-card-heading">
             <div class="text-base font-bold"><?php _e('Live Chat Assistant', 'thrivedesk'); ?></div>
-            <p><?php _e('Add live chat assistant to your website. To create your assistant click <a href="' . THRIVEDESK_APP_URL . '/chat/assistants" target="_blank">here</a>', 'thrivedesk'); ?></p>
+            <p><?php _e('Add live chat assistant to your website. To create your assistant click <a href="' . THRIVEDESK_APP_URL . '/chat/assistants" target="_blank">here</a>. And you can choose the routes where the assistant should not be visible.', 'thrivedesk'); ?></p>
         </div>
-        <div class="td-card">
+        <div class="td-card space-y-2">
             <?php if (!empty($td_assistants)) : ?>
                 <div class="space-y-2">
                     <label class="font-medium text-black text-sm"><?php _e('Select Assistant', 'thrivedesk'); ?></label>
@@ -73,6 +73,28 @@ $current_user = wp_get_current_user();
                         <?php endforeach; ?>
                     </select>
                 </div>
+
+                <div class="space-y-2">
+                        <label class="font-medium text-black text-sm"><?php _e('Exclude Routes', 'thrivedesk'); ?></label>
+                        <select name="td_excluded_routes[]" id="td-excluded-routes" class="mt-1 bg-gray-50 border border-gray-300 rounded px-2 py-1 w-full max-w-full" multiple>
+                            <?php
+                            $selected_routes = $td_helpdesk_selected_option['td_assistant_route_list'] ?? [];
+                            if (!is_array($selected_routes)) {
+                                $selected_routes = [];
+                            }
+                            foreach ($routes as $route) : ?>
+                                <option class="hover:text-blue-700" value="<?php echo esc_attr($route); ?>" <?php echo in_array($route, $selected_routes) ? 'selected' : ''; ?>>
+                                    <?php echo esc_html($route); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+
+                    <!-- Guidance for selecting multiple options -->
+                    <small class="text-gray-600 block mt-1">
+                        <?php _e('Hold down the <strong>Ctrl</strong> (or <strong>Cmd</strong> on Mac) key to select multiple routes.', 'thrivedesk'); ?>
+                    </small>
+                
             <?php else : ?>
                 <p class="text-lg flex flex-col items-center">
                     <span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="48" height="48" color="#000" fill="none">
@@ -86,36 +108,6 @@ $current_user = wp_get_current_user();
             <?php endif; ?>
         </div>
     </div>
-
-    <!-- assistant settings -->
-    <div class="space-y-1">
-        <div class="td-card-heading">
-            <div class="text-base font-bold"><?php _e('Select Routes', 'thrivedesk'); ?></div>
-            <p><?php _e('Choose the routes where the assistant should not be visible.', 'thrivedesk'); ?></p>
-        </div>
-        <div class="td-card">
-            <div class="space-y-2">
-                <label class="font-medium text-black text-sm"><?php _e('Exclude Routes', 'thrivedesk'); ?></label>
-                <select name="td_excluded_routes[]" id="td-excluded-routes" class="mt-1 bg-gray-50 border border-gray-300 rounded px-2 py-1 w-full max-w-full" multiple>
-                    <?php
-                    $selected_routes = $td_helpdesk_selected_option['td_assistant_route_list'] ?? [];
-                    if (!is_array($selected_routes)) {
-                        $selected_routes = [];
-                    }
-                    foreach ($routes as $route) : ?>
-                        <option class="hover:text-blue-700" value="<?php echo esc_attr($route); ?>" <?php echo in_array($route, $selected_routes) ? 'selected' : ''; ?>>
-                            <?php echo esc_html($route); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
-            <!-- Guidance for selecting multiple options -->
-            <small class="text-gray-600 block mt-1">
-                <?php _e('Hold down the <strong>Ctrl</strong> (or <strong>Cmd</strong> on Mac) key to select multiple routes.', 'thrivedesk'); ?>
-            </small>
-        </div>
-    </div>
-    <!-- end assistant settings -->
 
     <?php if ($wppostsync && $wppostsync->get_plugin_data('connected')) : ?>
         <!-- WP Post Sync  -->

--- a/includes/views/partials/settings.php
+++ b/includes/views/partials/settings.php
@@ -96,17 +96,25 @@ $current_user = wp_get_current_user();
         <div class="td-card">
             <div class="space-y-2">
                 <label class="font-medium text-black text-sm"><?php _e('Exclude Routes', 'thrivedesk'); ?></label>
-                <select name="td_excluded_routes[]" id="td-excluded-routes" class="mt-1 bg-gray-50 border border-gray-300 rounded px-2 py-1 w-full max-w-full">
-                    <?php foreach ($routes as $page_id => $route) : ?>
-                        <option value="<?php echo $route; ?>" <?php echo ($td_helpdesk_selected_option['td_assistant_route_list'] == $route) ? 'selected' : ''; ?>>
-                            <?php echo $route; ?>
+                <select name="td_excluded_routes[]" id="td-excluded-routes" class="mt-1 bg-gray-50 border border-gray-300 rounded px-2 py-1 w-full max-w-full" multiple>
+                    <?php
+                    $selected_routes = $td_helpdesk_selected_option['td_assistant_route_list'] ?? [];
+                    if (!is_array($selected_routes)) {
+                        $selected_routes = [];
+                    }
+                    foreach ($routes as $route) : ?>
+                        <option class="hover:text-blue-700" value="<?php echo esc_attr($route); ?>" <?php echo in_array($route, $selected_routes) ? 'selected' : ''; ?>>
+                            <?php echo esc_html($route); ?>
                         </option>
                     <?php endforeach; ?>
                 </select>
             </div>
+            <!-- Guidance for selecting multiple options -->
+            <small class="text-gray-600 block mt-1">
+                <?php _e('Hold down the <strong>Ctrl</strong> (or <strong>Cmd</strong> on Mac) key to select multiple routes.', 'thrivedesk'); ?>
+            </small>
         </div>
     </div>
-
     <!-- end assistant settings -->
 
     <?php if ($wppostsync && $wppostsync->get_plugin_data('connected')) : ?>

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -143,7 +143,8 @@ jQuery(document).ready(($) => {
 		e.preventDefault();
 		let td_helpdesk_api_key = $('#td_helpdesk_api_key').val();
 		let td_helpdesk_assistant = $('#td-assistants').val();
-		let td_assistant_route_list = $('#td-excluded-routes').val();
+		// Get the selected routes as an array
+		let td_assistant_route_list = $('#td-excluded-routes').val() || [];
 		let td_helpdesk_page_id = $('#td_helpdesk_page_id').val();
 		let td_knowledgebase_slug = $('#td_knowledgebase_slug').val();
 		let td_helpdesk_post_types = $('.td_helpdesk_post_types:checked')
@@ -169,7 +170,7 @@ jQuery(document).ready(($) => {
 					td_helpdesk_post_types: td_helpdesk_post_types,
 					td_helpdesk_post_sync: td_helpdesk_post_sync,
 					td_user_account_pages: td_user_account_pages,
-					td_assistant_route_list: td_assistant_route_list
+					td_assistant_route_list: td_assistant_route_list // This will be an array of selected routes
 				},
 			})
 			.success(function (response) {

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -143,6 +143,7 @@ jQuery(document).ready(($) => {
 		e.preventDefault();
 		let td_helpdesk_api_key = $('#td_helpdesk_api_key').val();
 		let td_helpdesk_assistant = $('#td-assistants').val();
+		let td_assistant_route_list = $('#td-excluded-routes').val();
 		let td_helpdesk_page_id = $('#td_helpdesk_page_id').val();
 		let td_knowledgebase_slug = $('#td_knowledgebase_slug').val();
 		let td_helpdesk_post_types = $('.td_helpdesk_post_types:checked')
@@ -168,6 +169,7 @@ jQuery(document).ready(($) => {
 					td_helpdesk_post_types: td_helpdesk_post_types,
 					td_helpdesk_post_sync: td_helpdesk_post_sync,
 					td_user_account_pages: td_user_account_pages,
+					td_assistant_route_list: td_assistant_route_list
 				},
 			})
 			.success(function (response) {

--- a/src/Assistants/Assistant.php
+++ b/src/Assistants/Assistant.php
@@ -56,10 +56,16 @@ class Assistant {
     public function load_assistant_script()
     {
         $assistant_id = get_td_helpdesk_options()['td_helpdesk_assistant_id'] ?? '';
+		$td_assistant_route_list = get_td_helpdesk_options()['td_assistant_route_list'] ?? '';
 
         if (empty($assistant_id)) {
             return;
         }
+		// Get the current URL
+		$current_url = $this->get_current_url();
+		if ($current_url === $td_assistant_route_list) {
+			return;
+		}
 
 	$current_user = wp_get_current_user();
         $assistant_script = '
@@ -79,6 +85,12 @@ class Assistant {
         ';
 
         echo $assistant_script;
+    }
+
+	public function get_current_url()
+    {
+        global $wp;
+        return home_url( add_query_arg( null, null ) );
     }
 
 	public function get_assistants(  $apiKey = '' ) {

--- a/src/Assistants/Assistant.php
+++ b/src/Assistants/Assistant.php
@@ -55,15 +55,16 @@ class Assistant {
 
     public function load_assistant_script()
     {
-        $assistant_id = get_td_helpdesk_options()['td_helpdesk_assistant_id'] ?? '';
-		$td_assistant_route_list = get_td_helpdesk_options()['td_assistant_route_list'] ?? '';
+		$assistant_id = get_td_helpdesk_options()['td_helpdesk_assistant_id'] ?? '';
+		$td_assistant_route_list = get_td_helpdesk_options()['td_assistant_route_list'] ?? [];
+		
+		if (empty($assistant_id)) {
+			return;
+		}
 
-        if (empty($assistant_id)) {
-            return;
-        }
 		// Get the current URL
 		$current_url = $this->get_current_url();
-		if ($current_url === $td_assistant_route_list) {
+		if (in_array($current_url, $td_assistant_route_list)) {
 			return;
 		}
 
@@ -88,10 +89,10 @@ class Assistant {
     }
 
 	public function get_current_url()
-    {
-        global $wp;
-        return home_url( add_query_arg( null, null ) );
-    }
+	{
+		global $wp;
+		return home_url(add_query_arg(null, null));
+	}
 
 	public function get_assistants(  $apiKey = '' ) {
 		$apiService = new TDApiService();

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -118,9 +118,9 @@ class Conversation
                 'td_helpdesk_post_types'                => $data['td_helpdesk_post_types'],
                 'td_helpdesk_post_sync'                 => $data['td_helpdesk_post_sync'],
 	            'td_user_account_pages'                 => $data['td_user_account_pages'],
-                'td_assistant_route_list'               => $data['td_assistant_route_list'],
+                'td_assistant_route_list'               => is_array($data['td_assistant_route_list']) ? $data['td_assistant_route_list'] : [],
             ];
-
+            
             if (get_option('td_helpdesk_settings')) {
                 update_option('td_helpdesk_settings', $td_helpdesk_settings);
             } else {

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -118,6 +118,7 @@ class Conversation
                 'td_helpdesk_post_types'                => $data['td_helpdesk_post_types'],
                 'td_helpdesk_post_sync'                 => $data['td_helpdesk_post_sync'],
 	            'td_user_account_pages'                 => $data['td_user_account_pages'],
+                'td_assistant_route_list'               => $data['td_assistant_route_list'],
             ];
 
             if (get_option('td_helpdesk_settings')) {


### PR DESCRIPTION
**Users can control the assistant's visibility based on their routes.** 
For example: 
you have navigations: Home, About Us, Billing, Checkout, Others
you don't want assistant in: Billing & Checkout

You have options in the Wordpress admin panel to select this.
![image](https://github.com/user-attachments/assets/898deac6-e7dd-42be-b3fe-f1ad9fa2c165)

resolves: https://github.com/orgs/thrivedesk/projects/1/views/1?pane=issue&itemId=74403055