### PR TITLE
fix: wrong organization data showing on changing the apikey issue

### DIFF
--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -294,7 +294,8 @@ jQuery(document).ready(($) => {
 					});
 				} else {
 					loadAssistants(apiKey);
-					isAllowedPortal()
+					isAllowedPortal();
+					$('#td_setting_btn_submit').click();
 
 					$target.text('Verified');
 					$target.prop('disabled', true);

--- a/src/Services/TDApiService.php
+++ b/src/Services/TDApiService.php
@@ -51,7 +51,15 @@ class TDApiService {
         return $body ?? [];
     }
 
+    public function clearAllTransients()
+    {
+        delete_transient('thrivedesk_assistants');
+        delete_transient('thrivedesk_conversations_total_pages');
+        delete_transient('thrivedesk_portal_access');
+    }
+
 	public function setApiKey( $apiKey ): void {
+        $this->clearAllTransients();
 		$this->api_token = $apiKey;
 	}
 }


### PR DESCRIPTION
resolves: https://github.com/thrivedesk/wp-thrivedesk/issues/98#issue-2563501528
This pull request includes changes to enhance the functionality of the admin interface and improve the `TDApiService` class by adding a method to clear transients. The most important changes include adding a click event trigger and a new method to clear transients when setting the API key.

Enhancements to admin interface:

* [`resources/js/admin.js`](diffhunk://#diff-e8418600457f75c82daf5628d5f22c8a32951b570755162d82ba310c9c8ec507L297-R298): Added a click event trigger for the `#td_setting_btn_submit` button after verifying the portal.

Improvements to `TDApiService`:

* [`src/Services/TDApiService.php`](diffhunk://#diff-a8db38f08215f0dec150cc32bc5b36a372c77f5e8013dff39893961a46116423R54-R62): Added the `clearAllTransients` method to delete specific transients and called this method within `setApiKey` to ensure transients are cleared when the API key is set.