### PR TITLE
Fix/sync wp post 2.1

### DIFF
--- a/includes/views/partials/settings.php
+++ b/includes/views/partials/settings.php
@@ -11,6 +11,8 @@ use ThriveDesk\Plugins\WPPostSync;
 $td_helpdesk_selected_option = get_td_helpdesk_options();
 $td_selected_post_types      = (array) $td_helpdesk_selected_option['td_helpdesk_post_types'] ?? [];
 $td_selected_post_sync       = (array) $td_helpdesk_selected_option['td_helpdesk_post_sync'] ?? [];
+
+
 $td_assistants               = Assistant::assistants();
 $td_inboxes                  = Inbox::inboxes();
 $td_knowledgebase            = KnowledgeBase::knowledgebase();

--- a/includes/views/partials/settings.php
+++ b/includes/views/partials/settings.php
@@ -9,8 +9,8 @@ use ThriveDesk\Services\PortalService;
 use ThriveDesk\Plugins\WPPostSync;
 
 $td_helpdesk_selected_option = get_td_helpdesk_options();
-$td_selected_post_types      = $td_helpdesk_selected_option['td_helpdesk_post_types'] ?? [];
-$td_selected_post_sync       = $td_helpdesk_selected_option['td_helpdesk_post_sync'] ?? [];
+$td_selected_post_types      = (array) $td_helpdesk_selected_option['td_helpdesk_post_types'] ?? [];
+$td_selected_post_sync       = (array) $td_helpdesk_selected_option['td_helpdesk_post_sync'] ?? [];
 $td_assistants               = Assistant::assistants();
 $td_inboxes                  = Inbox::inboxes();
 $td_knowledgebase            = KnowledgeBase::knowledgebase();
@@ -22,7 +22,7 @@ $wppostsync                  = WPPostSync::instance();
 $show_api_key_alert  = empty($td_api_key) ? '' : 'hidden';
 $show_portal         = empty($has_portal_access) ? 'hidden' : '';
 
-$td_selected_user_account_pages = $td_helpdesk_selected_option['td_user_account_pages'] ?? [];
+$td_selected_user_account_pages = (array) $td_helpdesk_selected_option['td_user_account_pages'] ?? [];
 $td_helpdesk_selected_option['td_knowledgebase_url'] = THRIVEDESK_KB_API_ENDPOINT;
 update_option('td_helpdesk_settings', $td_helpdesk_selected_option);
 
@@ -119,10 +119,7 @@ $current_user = wp_get_current_user();
                         <label class="font-medium text-black text-sm"><?php esc_html_e('Exclude Pages', 'thrivedesk'); ?></label>
                         <select name="td_excluded_routes[]" id="td-excluded-routes" class="mt-1 bg-gray-50 border border-gray-300 rounded px-2 py-1 w-full max-w-full" multiple>
                             <?php
-                            $selected_routes = $td_helpdesk_selected_option['td_assistant_route_list'] ?? [];
-                            if (!is_array($selected_routes)) {
-                                $selected_routes = [];
-                            }
+                            $selected_routes = (array) $td_helpdesk_selected_option['td_assistant_route_list'] ?? [];
                             foreach ($routes as $route) : ?>
                                 <option class="hover:text-blue-700" value="<?php echo esc_attr($route); ?>" <?php echo in_array($route, $selected_routes) ? 'selected' : ''; ?>>
                                     <?php echo esc_html($route); ?>
@@ -175,7 +172,9 @@ $current_user = wp_get_current_user();
                                     <div class="w-full text-center text-base tab-link">
                                         <?php esc_html_e('You need to install WordPress Post Sync app to get this feature', 'thrivedesk'); ?>
                                         <?php $nonce = wp_create_nonce('thrivedesk-plugin-action'); ?>
-                                        <a data-target="tab-integrations" href="#integrations" class="btn-primary py-1 px-3">Connect Now</a>
+                                        <a data-target="tab-integrations" href="#integrations" class="inline-block py-1 px-3 btn bg-blue-50 text-blue-600 hover:bg-blue-600 hover:text-white">
+                                            <?php esc_html_e('Connect Now', 'thrivedesk'); ?>
+                                        </a>
                                     </div>
                                 <?php endif; ?>
                             </div>

--- a/src/Assistants/Assistant.php
+++ b/src/Assistants/Assistant.php
@@ -58,7 +58,7 @@ class Assistant {
     public function load_assistant_script()
     {
 		$assistant_id = get_td_helpdesk_options()['td_helpdesk_assistant_id'] ?? '';
-		$td_assistant_route_list = get_td_helpdesk_options()['td_assistant_route_list'] ?? [];
+		$td_assistant_route_list = (array) get_td_helpdesk_options()['td_assistant_route_list'] ?? [];
 		
 		if (empty($assistant_id)) {
 			return;

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -246,7 +246,7 @@ class Conversation
                 'td_helpdesk_page_id'                   => $data['td_helpdesk_page_id'] ?? '',
                 'td_knowledgebase_slug'                 => $data['td_knowledgebase_slug'] ?? [],
                 'td_helpdesk_post_types'                => $data['td_helpdesk_post_types'] ?? [],
-                'td_helpdesk_post_sync'                 => $data['td_helpdesk_post_sync'] ?? '',
+                'td_helpdesk_post_sync'                 => $data['td_helpdesk_post_sync'] ?? [],
                     'td_user_account_pages'                 => $data['td_user_account_pages'] ?? [],
                 'td_assistant_route_list'               => $data['td_assistant_route_list'] ?? [],
             ];

--- a/src/Portal/UserAccountPages.php
+++ b/src/Portal/UserAccountPages.php
@@ -11,7 +11,7 @@ class UserAccountPages {
 
 	public function handle_pages() {
 		$td_helpdesk_selected_option    = get_td_helpdesk_options();
-		$td_selected_user_account_pages = $td_helpdesk_selected_option['td_user_account_pages'] ?? [];
+		$td_selected_user_account_pages = (array) $td_helpdesk_selected_option['td_user_account_pages'] ?? [];
 
 		$woo_plugin_installed = defined('WC_VERSION');
 

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'thrivedesk/wp-plugin',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => '4e81072540de3e254b42c6207dd8f726715124ff',
+        'reference' => '3e3ed20ed3e809e0c48c450a856674ae3a443c5a',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'thrivedesk/wp-plugin' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => '4e81072540de3e254b42c6207dd8f726715124ff',
+            'reference' => '3e3ed20ed3e809e0c48c450a856674ae3a443c5a',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'thrivedesk/wp-plugin',
         'pretty_version' => 'dev-develop',
         'version' => 'dev-develop',
-        'reference' => 'd7b127653ff187268dbb9400924929ca5881249d',
+        'reference' => '4e81072540de3e254b42c6207dd8f726715124ff',
         'type' => 'library',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'thrivedesk/wp-plugin' => array(
             'pretty_version' => 'dev-develop',
             'version' => 'dev-develop',
-            'reference' => 'd7b127653ff187268dbb9400924929ca5881249d',
+            'reference' => '4e81072540de3e254b42c6207dd8f726715124ff',
             'type' => 'library',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
This pull request focuses on improving the consistency and reliability of settings handling in the ThriveDesk plugin, especially around the treatment of array-based options and cache management. The changes ensure that settings values are always cast to arrays when expected, sanitize form data correctly, and clear caches after updates to prevent stale data issues.

**Settings handling improvements:**

* Ensured that settings options such as `td_helpdesk_post_types`, `td_helpdesk_post_sync`, `td_user_account_pages`, and `td_assistant_route_list` are always cast to arrays when retrieved in `includes/views/partials/settings.php`, `src/Assistants/Assistant.php`, and `src/Portal/UserAccountPages.php` to prevent type errors. [[1]](diffhunk://#diff-531908becfde0c35fd195c577e23cdae1f5c77a2c67032206cec17026c7a3b46L12-R15) [[2]](diffhunk://#diff-531908becfde0c35fd195c577e23cdae1f5c77a2c67032206cec17026c7a3b46L25-R27) [[3]](diffhunk://#diff-531908becfde0c35fd195c577e23cdae1f5c77a2c67032206cec17026c7a3b46L122-R124) [[4]](diffhunk://#diff-24003f5d9723c8dca1af868f5198d0c6fa788e86be84c2b830f80efb429a5c90L61-R61) [[5]](diffhunk://#diff-5f59bf2e8d51e802d697465785692f7353f9ebc91ba15e7d04805a880690634fL14-R14)
* Updated the settings save logic in `src/Conversations/Conversation.php` to sanitize both array and string form inputs properly, improving data integrity and security.

**Cache management:**

* Added logic to clear all ThriveDesk and WordPress options caches after saving settings, ensuring that changes are immediately reflected and stale data is not served.

**Form data structure consistency:**

* Modified the storage of `td_helpdesk_post_sync` in settings to always use an array, aligning it with how other multi-select options are handled.

**UI improvements:**

* Updated the "Connect Now" button styling and label in the integrations tab to improve user experience and maintain consistency with other buttons.