### PR TITLE
fix: Ship Composer autoloader in WordPress.org package

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,7 +5,6 @@
 /.git
 /.github
 /node_modules
-/vendor
 /scripts
 
 # Build configuration files

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -20,29 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Remove legacy vendor/ from WordPress.org trunk
-        env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        run: |
-          set -e
-          sudo apt-get update -y
-          sudo apt-get install -y subversion
-          svn checkout --depth infinity --non-interactive \
-            --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-            https://plugins.svn.wordpress.org/thrivedesk/trunk /tmp/td-trunk
-          cd /tmp/td-trunk
-          if svn info vendor >/dev/null 2>&1; then
-            echo "Removing vendor/ from trunk"
-            svn rm --non-interactive \
-              --username "$SVN_USERNAME" --password "$SVN_PASSWORD" vendor
-            svn commit --non-interactive --no-auth-cache \
-              --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-              -m "Remove vendor/ from trunk; tracked in git until 1ac2762 and should not ship in the WP.org distribution"
-          else
-            echo "vendor/ already absent from trunk, skipping"
-          fi
-
       - name: WordPress.org plugin asset/readme update
         uses: 10up/action-wordpress-plugin-asset-update@stable
         env:

--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -26,6 +26,16 @@ jobs:
           npm ci
           npm run production
 
+      - name: Verify packaged plugin includes the Composer autoloader
+        run: |
+          dist="$(mktemp -d)"
+          rsync -a --exclude-from=.distignore ./ "$dist/"
+          if [ ! -f "$dist/vendor/autoload.php" ]; then
+            echo "::error::vendor/autoload.php is missing from the deploy package — the plugin will fatal on load. Check .distignore and the Build step."
+            exit 1
+          fi
+          echo "Autoloader present in package: OK"
+
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,6 +23,7 @@ build() {
   cp -vr ./changelog.txt ./releases/thrivedesk
   cp -vr ./composer.json ./releases/thrivedesk
   cp -vr ./composer.lock ./releases/thrivedesk
+  cp -vr ./vendor ./releases/thrivedesk
   cp -vr ./thrivedesk.php ./releases/thrivedesk
 
   echo "[+] Finished combingFiles"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages now include required dependency files, improving deployment readiness.

* **Bug Fixes**
  * Added a build-time check to catch missing autoloader files before deployment.
  * Prevented deployments from omitting the packaged `vendor` directory, reducing runtime errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->