### PR TITLE
fix(api): preserve custom order numbers in order-status lookup

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -195,7 +195,9 @@ final class Api {
 	 */
 	public function get_woocommerce_order_status() {
 		$email    = sanitize_email( $_REQUEST['email'] ?? '' );
-		$order_id = sanitize_key( $_REQUEST['order_id'] ?? '' );
+		// Use sanitize_text_field instead of sanitize_key because custom order numbers
+		// can contain characters like slashes, dashes, or spaces (e.g., "2025/001").
+		$order_id = sanitize_text_field( wp_unslash( $_REQUEST['order_id'] ?? '' ) );
 
 		if ( ! $order_id ) {
 			$this->apiResponse->error( 400, 'order_id is required.' );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,9 +43,32 @@ if ( file_exists( $_polyfills . '/phpunitpolyfills-autoload.php' ) ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
+/**
+ * Load WooCommerce if available before loading our plugin.
+ */
 function _td_manually_load_plugin() {
+    $woocommerce = WP_PLUGIN_DIR . '/woocommerce/woocommerce.php';
+    if ( file_exists( $woocommerce ) ) {
+        require $woocommerce;
+    }
+
     require dirname( __DIR__ ) . '/thrivedesk.php';
 }
 tests_add_filter( 'muplugins_loaded', '_td_manually_load_plugin' );
+
+/**
+ * Install WooCommerce tables on test setup.
+ */
+function _td_install_woocommerce() {
+    if ( ! class_exists( 'WC_Install' ) ) {
+        return;
+    }
+
+    WC_Install::install();
+
+    // Rebuild roles cache to include WooCommerce capabilities.
+    $GLOBALS['wp_roles'] = null;
+}
+tests_add_filter( 'setup_theme', '_td_install_woocommerce' );
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-order-status.php
+++ b/tests/test-order-status.php
@@ -52,6 +52,46 @@ class TD_Order_Status_Test extends WP_UnitTestCase {
     }
 
     /**
+     * Helper to mock and dispatch an order status request and capture the response.
+     *
+     * @param  string  $email
+     * @param  string  $order_id
+     * @return array
+     * @throws ReflectionException
+     */
+    private function dispatch_order_status_request( string $email, string $order_id ): array {
+        $api = \ThriveDesk\Api::instance();
+
+        // Inject the plugin instance into the Api singleton.
+        $plugin_prop = ( new \ReflectionClass( $api ) )->getProperty( 'plugin' );
+        $plugin_prop->setAccessible( true );
+        $plugin_prop->setValue( $api, $this->plugin );
+
+        $_REQUEST['email']    = $email;
+        $_REQUEST['order_id'] = $order_id;
+
+        // Catch wp_die calls to capture output from wp_send_json.
+        add_filter( 'wp_doing_ajax', '__return_true' );
+        add_filter( 'wp_die_ajax_handler', static function () {
+            return static function () {
+                throw new \WPDieException( 'wp_die' );
+            };
+        } );
+
+        ob_start();
+        try {
+            $api->get_woocommerce_order_status();
+        } catch ( \WPDieException $e ) {
+            // Expected exception from wp_die.
+        }
+        $body = ob_get_clean();
+
+        unset( $_REQUEST['email'], $_REQUEST['order_id'] );
+
+        return json_decode( $body, true ) ?: [];
+    }
+
+    /**
      * Reproduces issue #167: a customer has two orders. Asking for one
      * must return THAT order, not the other.
      */
@@ -63,16 +103,17 @@ class TD_Order_Status_Test extends WP_UnitTestCase {
 
         $result = $this->plugin->order_status( '71382' );
 
-        $this->assertNotEmpty( $result, 'Asking for order 71382 must return an order.' );
-        $this->assertSame(
-            $order_a,
-            $this->find_post_id_for_order_number( $result['order_id'] ?? '' ),
-            'Asking for sequential number 71382 must return the post whose _order_number is 71382, not the other order under the same email.'
-        );
+        $this->assertNotEmpty( $result, 'Order should be found.' );
         $this->assertNotSame(
             $order_a,
             $order_b,
-            'Test fixture sanity: the two orders must be different posts.'
+            'Fixture sanity check: orders must be different.'
+        );
+        // With no numbering plugin active, order_id should equal the default post ID.
+        $this->assertSame(
+            (string) $order_a,
+            (string) ( $result['order_id'] ?? '' ),
+            'Should return order A, not order B.'
         );
     }
 
@@ -148,24 +189,38 @@ class TD_Order_Status_Test extends WP_UnitTestCase {
     }
 
     /**
-     * Look up the post whose _order_number equals the given string. Helper
-     * for assertions, since the helper returns the order's user-facing
-     * number (which the active numbering plugin controls), not the post id.
+     * Test resolving order status with non-numeric characters in the order number.
      */
-    private function find_post_id_for_order_number( string $user_facing_number ): int {
-        $posts = get_posts( [
-            'post_type'      => wc_get_order_types( 'view-orders' ) ?: [ 'shop_order' ],
-            'post_status'    => array_keys( wc_get_order_statuses() ) ?: [ 'any' ],
-            'posts_per_page' => 1,
-            'fields'         => 'ids',
-            'meta_query'     => [
-                [
-                    'key'   => '_order_number',
-                    'value' => $user_facing_number,
-                ],
-            ],
-        ] );
+    public function test_order_status_resolves_order_number_with_special_characters() {
+        $this->create_order_with_sequential_number( self::LYNNE_EMAIL, '2025/001' );
 
-        return $posts[0] ?? 0;
+        $this->plugin->customer_email = self::LYNNE_EMAIL;
+
+        $result = $this->plugin->order_status( '2025/001' );
+
+        $this->assertNotEmpty(
+            $result,
+            'Order status should resolve for invoice-style order numbers.'
+        );
+    }
+
+    /**
+     * Test that the API endpoint preserves custom order number characters.
+     */
+    public function test_order_status_endpoint_preserves_custom_order_number() {
+        $order_id = $this->create_order_with_sequential_number( self::LYNNE_EMAIL, '2025/001' );
+
+        $response = $this->dispatch_order_status_request( self::LYNNE_EMAIL, '2025/001' );
+
+        $this->assertSame(
+            'Success',
+            $response['message'] ?? null,
+            'API should return a successful response.'
+        );
+        $this->assertSame(
+            (string) $order_id,
+            (string) ( $response['data']['order_id'] ?? '' ),
+            'API should return the correct order details.'
+        );
     }
 }


### PR DESCRIPTION
### Overview

The `get_woocommerce_order_status()` endpoint was sanitizing incoming `order_id`s using `sanitize_key()`. Because `sanitize_key()` strips all characters outside of `[a-z0-9_-]`, it actively mangled custom order numbers containing special characters before they ever reached the resolver.

Examples of the stripping behavior:

* `2025/001` → `2025001`
* `#1234` → `1234`
* `Order #1001` → `order1001`

Consequently, the resolver (`WooCommerce::get_order_by_number_or_id()`) never received the correct string. This caused custom orders generated by plugins like WebToffee, SkyVerge, and Tyche to return a **404 Order not found**, rendering the lookup feature a no-op for the exact shops it was built to support.

This PR fixes the issue by replacing `sanitize_key()` with `sanitize_text_field( wp_unslash( ... ) )`. This safely preserves necessary characters (slashes, hashes, spaces) while remaining completely secure against SQL injection, as the value is bound downstream via `$wpdb->prepare()` `%s`.

### Changes

* **`src/Api.php`:** Updated sanitization in `get_woocommerce_order_status()` to use `sanitize_text_field( wp_unslash() )` instead of `sanitize_key()`.
* **`tests/test-order-status.php`:**
* Added `test_order_status_endpoint_preserves_custom_order_number` to hit the real endpoint (capturing `wp_send_json` output). This fails on `main` and passes with this fix.
* Added `test_order_status_resolves_order_number_with_special_characters` for resolver-level coverage of non-numeric formats.
* Tightened the assertion for Issue #167 to assert the resolved order ID directly.


* **`tests/bootstrap.php`:** Configured the test harness to load WooCommerce and run `WC_Install::install()`. This ensures integration tests execute against real WooCommerce objects/tables rather than being skipped.

### How to Test

**Automated Tests:**

1. Run `composer install`.
2. Run `composer test` to execute the full PHPUnit suite (15 tests). *(Note: Requires a WordPress test database with WooCommerce available).*
3. Run `composer phpcs` to ensure linting passes on the touched files.

**Manual Testing:**

1. Create a WooCommerce order and set the `_order_number` meta value to a string containing special characters (e.g., `2025/001`).
2. Call the order-status API endpoint using that exact custom order number.
3. Verify the API successfully resolves the order instead of returning a 404.

### Out of Scope / Next Steps

Order *mutation* handlers (status update, quantity, coupon, add/remove item) currently still bypass the resolver by resolving `order_id` via `sanitize_key()` + `wc_get_order()` directly.

As a result, they remain broken for custom-numbered orders. This is documented via a `TODO` note in `src/Api.php` (near the add-item handler) and will be tracked and addressed in a separate PR to keep this scope strictly focused on the lookup path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order status lookups so custom order numbers with special characters are handled correctly.
  * Preserved the original order number format in order status responses.
  * Tightened test coverage for customers with multiple orders and custom order-number formats.

* **Tests**
  * Expanded automated tests for WooCommerce order status behavior.
  * Updated test setup to initialize WooCommerce more fully during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->