### PR TITLE
fix(release): generate readme.txt from readme.md for WordPress.org deploy

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -37,8 +37,8 @@ tests/
 .circleci/
 .codeclimate.yml
 
-# Documentation (if not needed in release)
-README.md
+# Exclude readme.md since wp.org uses the generated readme.txt
+readme.md
 CHANGELOG.md
 CONTRIBUTING.md
 

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # wp.org requires readme.txt
+      - name: Generate readme.txt for WordPress.org
+        run: cp readme.md readme.txt
+
       - name: WordPress.org plugin asset/readme update
         uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # 2.2.0
         env:

--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -26,6 +26,10 @@ jobs:
           npm ci
           npm run production
 
+      # wp.org requires readme.txt
+      - name: Generate readme.txt for WordPress.org
+        run: cp readme.md readme.txt
+
       - name: Verify packaged plugin includes the Composer autoloader
         run: |
           dist="$(mktemp -d)"

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ assets/bower_components/*
 # Compiled Files and Build Dirs #
 ##########
 /README.html
+# Generated deploy artifact
+/readme.txt
 
 # PhpStrom Project Files #
 .idea/


### PR DESCRIPTION
### Overview

Both WordPress.org deployment workflows were failing with the following error:

```text
cp: cannot stat '.../readme.txt': No such file or directory

```

This occurred because the repository uses `readme.md` (renamed in a previous commit), but WordPress.org's tooling and the plugin directory strictly require a `readme.txt` file to parse plugin information and deploy tags. Without it, the deployment crashes, and even if it succeeded, the plugin's directory page would be blank.

Because our `readme.md` is already formatted using WP.org syntax (e.g., `=== Plugin Name ===`, `Stable Tag:`, `== Description ==`), it just needed the correct file extension.

To maintain a single source of truth, this PR keeps `readme.md` as the GitHub-facing source and dynamically generates the `readme.txt` during the GitHub Actions workflows, right before the 10up action runs. It also ensures the `.md` file is excluded from the final SVN package so only the canonical `.txt` is shipped.

### Changes

* **`.github/workflows/wordpress-org-deploy.yml`:** Added a "Generate readme.txt" step (`cp readme.md readme.txt`) after the build and before the deploy.
* **`.github/workflows/push-asset-readme-update.yml`:** Added the same generation step after checkout.
* **`.distignore`:** Added `readme.md` (lowercase) to exclude it from the SVN release. *Note: The previous `README.md` entry never matched on case-sensitive Linux runners, which resulted in the `.md` accidentally shipping to trunk while the `.txt` was absent.*
* **`.gitignore`:** Ignored the dynamically generated `readme.txt` to prevent it from being accidentally committed to version control.

### How to Test

You can reproduce the deployment's file selection locally to verify the correct files are packaged:

```bash
# 1. Generate the txt file
cp readme.md readme.txt

# 2. Mock the distribution directory creation
dist="$(mktemp -d)"
rsync -a --exclude-from=.distignore ./ "$dist/"

# 3. Verify file presence/absence
ls "$dist/readme.txt"  # Should be present
ls "$dist/readme.md"   # Should be absent (excluded)

# 4. Clean up
rm readme.txt