### PR TITLE
fix(fluentcrm): emit stored submission time for ticket list

### DIFF
--- a/Hooks/FluentCrmHooks.php
+++ b/Hooks/FluentCrmHooks.php
@@ -110,16 +110,7 @@ class FluentCrmHooks {
 						$formatted_tickets = array();
 
 						foreach ( $td_conversations as $td_conversation ) {
-							$conversation_url = THRIVEDESK_APP_URL . '/conversations/' . $td_conversation->id;
-
-							$action_html         = '<a target="_blank" href="' . $conversation_url . '">View conversation</a>';
-							$formatted_tickets[] = array(
-								'id'           => '#' . $td_conversation->ticket_id,
-								'title'        => $td_conversation->title,
-								'status'       => $td_conversation->status,
-								'Submitted at' => gmdate( $td_conversation->created_at ),
-								'action'       => $action_html,
-							);
+							$formatted_tickets[] = self::format_ticket( $td_conversation );
 						}
 
 						return array(
@@ -131,6 +122,25 @@ class FluentCrmHooks {
 					2
 				);
 			}
+		);
+	}
+
+	/**
+	 * Shape a stored conversation row into a FluentCRM ticket entry.
+	 *
+	 * @param object $conversation Row from the conversations table.
+	 * @return array
+	 */
+	public static function format_ticket( object $conversation ): array {
+		$conversation_url = THRIVEDESK_APP_URL . '/conversations/' . $conversation->id;
+		$action_html      = '<a target="_blank" href="' . $conversation_url . '">View conversation</a>';
+
+		return array(
+			'id'           => '#' . $conversation->ticket_id,
+			'title'        => $conversation->title,
+			'status'       => $conversation->status,
+			'Submitted at' => $conversation->created_at,
+			'action'       => $action_html,
 		);
 	}
 }

--- a/tests/FluentCrmTicketFormatTest.php
+++ b/tests/FluentCrmTicketFormatTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * FluentCrmHooks::format_ticket shapes a stored conversation row into the ticket
+ * array FluentCRM renders. "Submitted at" must carry the stored submission time,
+ * not a value derived from the current time.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class FluentCrmTicketFormatTest extends WP_UnitTestCase {
+
+	private function conversation(): object {
+		return (object) array(
+			'id'         => 'conv_abc',
+			'ticket_id'  => 42,
+			'title'      => 'Need a hand',
+			'status'     => 'open',
+			'created_at' => '2024-01-02 03:04:05',
+		);
+	}
+
+	public function test_submitted_at_is_the_stored_timestamp() {
+		$row = \ThriveDesk\FluentCrmHooks::format_ticket( $this->conversation() );
+
+		$this->assertSame( '2024-01-02 03:04:05', $row['Submitted at'] );
+	}
+
+	public function test_maps_conversation_fields_to_ticket_shape() {
+		$row = \ThriveDesk\FluentCrmHooks::format_ticket( $this->conversation() );
+
+		$this->assertSame( '#42', $row['id'] );
+		$this->assertSame( 'Need a hand', $row['title'] );
+		$this->assertSame( 'open', $row['status'] );
+		$this->assertStringContainsString( '/conversations/conv_abc', $row['action'] );
+	}
+}


### PR DESCRIPTION
When FluentCRM displays the ticket list, the "Submitted at" field was incorrectly generated using `gmdate()` at render time, instead of emitting the actual stored submission timestamp from the database. This caused all tickets to show the current time rather than when they were actually created.

Extracted the ticket formatting logic into a dedicated `format_ticket()` method that uses the stored `created_at` timestamp directly, removing the dynamic time conversion.

### Changes
- **Hooks/FluentCrmHooks.php**: Refactored inline ticket formatting into `format_ticket()` static method that preserves the stored `created_at` value
- **tests/FluentCrmTicketFormatTest.php**: Added test suite to verify the stored timestamp is correctly passed through to the "Submitted at" field

## Impact
- Ticket timestamps now accurately reflect when they were created
- Code is now reusable and easier to test
- Reduces duplication in the hook callback

## Testing
Two new unit tests validate:
1. The stored submission timestamp is correctly emitted
2. All conversation fields map correctly to the ticket structure
