### PR TITLE
chore(wpcs): enforce the standard on src/Abstracts, src/Api and src/Portal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5339,6 +5339,72 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+			"version": "2.8.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "0BSD",
+			"optional": true
+		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
@@ -13136,9 +13202,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@wordpress/scripts": "^32.0.0",
 				"cssnano": "^5.1.14",
 				"laravel-mix": "^6.0.49",
-				"postcss": "^8.4.21",
+				"postcss": "^8.5.23",
 				"tailwindcss": "^4.0.0"
 			}
 		},
@@ -5338,6 +5338,72 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+			"version": "2.8.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "0BSD",
+			"optional": true
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.3.2",
@@ -18650,9 +18716,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.15",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-			"integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -19953,9 +20019,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.16",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -19973,7 +20039,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5339,6 +5339,72 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+			"version": "2.8.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "0BSD",
+			"optional": true
+		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
@@ -20759,9 +20825,9 @@
 			}
 		},
 		"node_modules/postcss-svgo/node_modules/svgo": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
-			"integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
+			"integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23911,9 +23977,9 @@
 			"dev": true
 		},
 		"node_modules/svgo": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-			"integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+			"integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/scripts": "^32.0.0",
 		"cssnano": "^5.1.14",
 		"laravel-mix": "^6.0.49",
-		"postcss": "^8.4.21",
+		"postcss": "^8.5.23",
 		"tailwindcss": "^4.0.0"
 	},
 	"dependencies": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,8 +10,22 @@
     <exclude-pattern>*/assets/*</exclude-pattern>
     <exclude-pattern>*/tests/*</exclude-pattern>
 
-    <!-- Legacy source is excluded while we adopt WPCS incrementally; drop a line as its directory goes clean. -->
-    <exclude-pattern>*/src/*</exclude-pattern>
+    <!-- Legacy source is excluded while we adopt WPCS incrementally. Listed one
+         path at a time rather than a blanket */src/* so the remaining debt is
+         visible: bring a path clean, delete its line, and it stays enforced.
+         Anything under src/ not listed here is already clean. -->
+    <exclude-pattern>*/src/Admin.php</exclude-pattern>
+    <exclude-pattern>*/src/Api.php</exclude-pattern>
+    <exclude-pattern>*/src/RestRoute.php</exclude-pattern>
+    <exclude-pattern>*/src/Assistants/*</exclude-pattern>
+    <exclude-pattern>*/src/Conversations/*</exclude-pattern>
+    <!-- Needs its camelCase accessors renamed to snake_case, which changes two
+         call sites in src/Plugins and its test. Code change, not formatting. -->
+    <exclude-pattern>*/src/Data/*</exclude-pattern>
+    <exclude-pattern>*/src/Inboxes/*</exclude-pattern>
+    <exclude-pattern>*/src/KnowledgeBase/*</exclude-pattern>
+    <exclude-pattern>*/src/Plugins/*</exclude-pattern>
+    <exclude-pattern>*/src/Services/*</exclude-pattern>
     <exclude-pattern>*/includes/*</exclude-pattern>
 
     <arg name="extensions" value="php"/>

--- a/src/Abstracts/Plugin.php
+++ b/src/Abstracts/Plugin.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Base class every ThriveDesk integration extends.
+ *
+ * @package ThriveDesk
+ */
 
 namespace ThriveDesk;
 
@@ -7,6 +12,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Shared contract and order maths for the per-platform integrations.
+ */
 abstract class Plugin {
 	/**
 	 * Customer email
@@ -60,7 +68,7 @@ abstract class Plugin {
 	/**
 	 * Get plugin data
 	 *
-	 * @param  string  $key
+	 * @param string $key Key to read from the integration's stored options; empty returns them all.
 	 *
 	 * @return mixed
 	 */
@@ -83,7 +91,7 @@ abstract class Plugin {
 	/**
 	 * Get the formated amount
 	 *
-	 * @param  float  $amount
+	 * @param float $amount Raw order amount.
 	 *
 	 * @return string
 	 */
@@ -101,46 +109,53 @@ abstract class Plugin {
 	/**
 	 * Get the accepted orders only
 	 *
-	 * @param  array  $orders
+	 * @param array $orders Orders as returned by get_orders().
 	 *
 	 * @return array
 	 */
 	public function filter_accepted_orders( array $orders ): array {
-		$accepted_statuses = $this->accepted_statuses() ?? [];
+		$accepted_statuses = $this->accepted_statuses() ?? array();
 
-		return array_filter( $orders, function ( $order ) use ( $accepted_statuses ) {
-			return in_array( $order['order_status'], $accepted_statuses );
-		} );
+		return array_filter(
+			$orders,
+			function ( $order ) use ( $accepted_statuses ) {
+				return in_array( $order['order_status'], $accepted_statuses, true );
+			}
+		);
 	}
 
 	/**
 	 * Get the lifetime order value of the customer
 	 *
-	 * @param  array  $orders
+	 * @param array $orders Accepted orders.
 	 *
 	 * @return float
 	 */
 	public function get_lifetime_order( array $orders ): float {
-		// TODO: Ignore pending or refunded amounts
+		// TODO: Ignore pending or refunded amounts.
 		return array_sum( array_column( $orders, 'amount' ) );
 	}
 
 	/**
 	 * Get this year order value of the customer
 	 *
-	 * @param  array  $orders
+	 * @param array $orders Accepted orders.
 	 *
 	 * @return float
 	 */
 	public function get_this_year_order( array $orders ): float {
-		// TODO: Ignore pending or refunded amounts
-		return array_reduce( $orders, function ( $carry, $item ) {
-			if ( strtotime( $item['date'] ) >= strtotime( '-1 year' ) ) {
-				$carry += (float) $item['amount'];
-			}
+		// TODO: Ignore pending or refunded amounts.
+		return array_reduce(
+			$orders,
+			function ( $carry, $item ) {
+				if ( strtotime( $item['date'] ) >= strtotime( '-1 year' ) ) {
+					$carry += (float) $item['amount'];
+				}
 
-			return $carry;
-		}, 0 );
+				return $carry;
+			},
+			0
+		);
 	}
 
 	/**
@@ -163,14 +178,14 @@ abstract class Plugin {
 
 		$avg_order = number_format( (float) $avg_order, 2, '.', '' );
 
-		return [
-			"customer"        => $customer,
-			"customer_since"  => $customer['registered_at'] ?? '',
-			"lifetime_order"  => $this->get_formated_amount( $lifetime_order ),
-			"this_year_order" => $this->get_formated_amount( $this_year_order ),
-			"avg_order"       => $this->get_formated_amount( $avg_order ),
-			"orders"          => $orders,
-			'add_order'       => admin_url( "post-new.php?post_type=shop_order" ) ?? '',
-		];
+		return array(
+			'customer'        => $customer,
+			'customer_since'  => $customer['registered_at'] ?? '',
+			'lifetime_order'  => $this->get_formated_amount( $lifetime_order ),
+			'this_year_order' => $this->get_formated_amount( $this_year_order ),
+			'avg_order'       => $this->get_formated_amount( $avg_order ),
+			'orders'          => $orders,
+			'add_order'       => admin_url( 'post-new.php?post_type=shop_order' ) ?? '',
+		);
 	}
 }

--- a/src/Api/ApiResponse.php
+++ b/src/Api/ApiResponse.php
@@ -1,12 +1,20 @@
 <?php
+/**
+ * JSON response builder for the ?listener= endpoint.
+ *
+ * @package ThriveDesk
+ */
 
 namespace ThriveDesk\Api;
 
 // Exit if accessed directly.
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Fluent builder that terminates the request with a JSON body.
+ */
 class ApiResponse {
 	/**
 	 * Response status
@@ -32,9 +40,9 @@ class ApiResponse {
 	/**
 	 * Response data
 	 *
-	 * @var Array|Object
+	 * @var array|object
 	 */
-	public $data = [];
+	public $data = array();
 
 	/**
 	 * Construct Response class.
@@ -45,41 +53,84 @@ class ApiResponse {
 	public function __construct() {
 	}
 
-	public function status_code(int $status_code): object {
+	/**
+	 * Set the HTTP status code.
+	 *
+	 * @param int $status_code HTTP status code.
+	 *
+	 * @return object
+	 */
+	public function status_code( int $status_code ): object {
 		$this->status_code = $status_code;
 
 		return $this;
 	}
 
-	public function message(string $message): object {
+	/**
+	 * Set the response message.
+	 *
+	 * @param string $message Human-readable message.
+	 *
+	 * @return object
+	 */
+	public function message( string $message ): object {
 		$this->message = $message;
 
 		return $this;
 	}
 
-	public function data(array $data): object {
+	/**
+	 * Set the response payload.
+	 *
+	 * @param array $data Payload returned under the 'data' key.
+	 *
+	 * @return object
+	 */
+	public function data( array $data ): object {
 		$this->data = $data;
 
 		return $this;
 	}
 
-	public function error(int $status_code, string $message = '') {
-		return $this->status_code($status_code)->message($message)->send();
+	/**
+	 * Send an error response and end the request.
+	 *
+	 * @param int    $status_code HTTP status code.
+	 * @param string $message     Human-readable message.
+	 *
+	 * @return void
+	 */
+	public function error( int $status_code, string $message = '' ) {
+		$this->status_code( $status_code )->message( $message )->send();
 	}
 
-	public function success(int $status_code = 200, array $data = [], string $message = '') {
-		return $this->status_code($status_code)->data($data)->message($message)->send();
+	/**
+	 * Send a success response and end the request.
+	 *
+	 * @param int    $status_code HTTP status code.
+	 * @param array  $data        Payload returned under the 'data' key.
+	 * @param string $message     Human-readable message.
+	 *
+	 * @return void
+	 */
+	public function success( int $status_code = 200, array $data = array(), string $message = '' ) {
+		$this->status_code( $status_code )->data( $data )->message( $message )->send();
 	}
 
+	/**
+	 * Emit the JSON body. wp_send_json() ends the request.
+	 *
+	 * @return void
+	 */
 	public function send(): void {
-		$response = [
+		$response = array(
 			'message' => $this->message,
-		];
+		);
 
-		if (true === $this->status && $this->data) {
+		if ( true === $this->status && $this->data ) {
 			$response['data'] = $this->data;
 		}
 
-		wp_send_json($response, $this->status_code);
+		wp_send_json( $response, $this->status_code );
 	}
 }

--- a/src/Portal/UserAccountPages.php
+++ b/src/Portal/UserAccountPages.php
@@ -1,39 +1,78 @@
 <?php
+/**
+ * Support tab wired into the customer's WooCommerce account page.
+ *
+ * @package ThriveDesk
+ */
 
 namespace ThriveDesk\Portal;
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers the /my-account/td-support/ endpoint and its account-page tab.
+ */
 class UserAccountPages {
-	// Flag set when the WC "Support" tab toggle flips; tells us rewrite rules
-	// need a refresh on the next request.
+
+	/**
+	 * Flag set when the WC "Support" tab toggle flips; tells us rewrite rules
+	 * need a refresh on the next request.
+	 */
 	const FLUSH_FLAG_OPTION = 'td_flush_rewrite_needed';
 
+	/**
+	 * Singleton instance.
+	 *
+	 * @var UserAccountPages|null
+	 */
 	private static $instance = null;
 
+	/**
+	 * Hook the account-page wiring into the boot sequence.
+	 */
 	public function __construct() {
-		add_action( 'plugins_loaded', [ $this, 'handle_pages' ] );
-		add_action( 'init', [ $this, 'maybe_flush_rewrite_rules' ], 99 );
+		add_action( 'plugins_loaded', array( $this, 'handle_pages' ) );
+		add_action( 'init', array( $this, 'maybe_flush_rewrite_rules' ), 99 );
 	}
 
+	/**
+	 * Wire up whichever account pages the admin selected.
+	 *
+	 * @return void
+	 */
 	public function handle_pages() {
 		$td_helpdesk_selected_option    = get_td_helpdesk_settings();
-		$td_selected_user_account_pages = (array) ($td_helpdesk_selected_option['td_user_account_pages'] ?? []);
+		$td_selected_user_account_pages = (array) ( $td_helpdesk_selected_option['td_user_account_pages'] ?? array() );
 
-		$woo_plugin_installed = defined('WC_VERSION');
+		$woo_plugin_installed = defined( 'WC_VERSION' );
 
-		if ( ! empty( $td_selected_user_account_pages )  ) {
+		if ( ! empty( $td_selected_user_account_pages ) ) {
 			if ( in_array( 'woocommerce', $td_selected_user_account_pages, true ) && $woo_plugin_installed ) {
 				$this->woocommerce_account_page_handler();
 			}
 		}
 	}
 
+	/**
+	 * Register the endpoint, query var, tab, and content callback with WooCommerce.
+	 *
+	 * @return void
+	 */
 	public function woocommerce_account_page_handler() {
-		add_action( 'init', [ $this, 'register_td_portal_endpoint_for_woocommerce_account_page' ] );
-		add_filter( 'query_vars', [ $this, 'td_portal_query_vars' ] );
-		add_filter( 'woocommerce_account_menu_items', [ $this, 'add_td_portal_tab_into_account_page' ] );
-		add_action( 'woocommerce_account_td-support_endpoint', [ $this, 'add_td_portal_content_into_account_page' ] );
+		add_action( 'init', array( $this, 'register_td_portal_endpoint_for_woocommerce_account_page' ) );
+		add_filter( 'query_vars', array( $this, 'td_portal_query_vars' ) );
+		add_filter( 'woocommerce_account_menu_items', array( $this, 'add_td_portal_tab_into_account_page' ) );
+		add_action( 'woocommerce_account_td-support_endpoint', array( $this, 'add_td_portal_content_into_account_page' ) );
 	}
 
+	/**
+	 * Retrieve the singleton instance.
+	 *
+	 * @return UserAccountPages
+	 */
 	public static function instance(): UserAccountPages {
 		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof UserAccountPages ) ) {
 			self::$instance = new self();
@@ -42,6 +81,11 @@ class UserAccountPages {
 		return self::$instance;
 	}
 
+	/**
+	 * Register the td-support rewrite endpoint.
+	 *
+	 * @return void
+	 */
 	public function register_td_portal_endpoint_for_woocommerce_account_page() {
 		add_rewrite_endpoint( 'td-support', EP_ROOT | EP_PAGES );
 	}
@@ -53,8 +97,10 @@ class UserAccountPages {
 	 * so flipping the toggle has to schedule a flush. If the toggle stays the
 	 * same we bail out, otherwise every settings save would flush for nothing.
 	 *
-	 * @param string[] $old_pages
-	 * @param string[] $new_pages
+	 * @param string[] $old_pages Account pages selected before the save.
+	 * @param string[] $new_pages Account pages selected after the save.
+	 *
+	 * @return void
 	 */
 	public function maybe_queue_rewrite_flush( array $old_pages, array $new_pages ): void {
 		$old_has_wc = in_array( 'woocommerce', $old_pages, true );
@@ -72,6 +118,8 @@ class UserAccountPages {
 	 * (init:10) has already run by the time we flush. That way the new rules
 	 * pick up the endpoint when WC support is on and drop it when off. Without
 	 * this, /my-account/td-support/ stays 404 until someone re-saves permalinks.
+	 *
+	 * @return void
 	 */
 	public function maybe_flush_rewrite_rules(): void {
 		if ( get_option( self::FLUSH_FLAG_OPTION ) ) {
@@ -80,6 +128,13 @@ class UserAccountPages {
 		}
 	}
 
+	/**
+	 * Register the endpoint's query var.
+	 *
+	 * @param string[] $vars Registered query vars.
+	 *
+	 * @return string[]
+	 */
 	public function td_portal_query_vars( $vars ) {
 
 		$vars[] = 'td-support';
@@ -87,13 +142,27 @@ class UserAccountPages {
 		return $vars;
 	}
 
+	/**
+	 * Add the Support tab to the account-page menu.
+	 *
+	 * @param string[] $items Account menu items.
+	 *
+	 * @return string[]
+	 */
 	public function add_td_portal_tab_into_account_page( $items ) {
 		$items['td-support'] = __( 'Support', 'thrivedesk' );
 
 		return $items;
 	}
 
+	/**
+	 * Render the portal inside the account page.
+	 *
+	 * @return void
+	 */
 	public function add_td_portal_content_into_account_page() {
-		echo do_shortcode( '[thrivedesk_portal]' );
+		// The shortcode renders the plugin's own portal markup; escaping it here
+		// would strip the layout.
+		echo do_shortcode( '[thrivedesk_portal]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }


### PR DESCRIPTION
Here is the cleaned-up, properly formatted Markdown ready to be copied and pasted directly into your GitHub PR description. I have removed the hard line breaks so the text flows dynamically and converted the "remaining debt" section into a scannable list.

---

## What

First `src/` increment of the incremental WPCS adoption started in #191, which brought `Hooks/` and `database/` under the full WordPress standard.

Replaces the blanket `*/src/*` exclude in `phpcs.xml` with **one `exclude-pattern` line per still-excluded path**. The remaining debt is then readable in the ruleset itself, and a path becomes enforced by deleting its line rather than by editing a wildcard.

Three paths go clean and enforced:

| Path | Violations |
| --- | --- |
| `src/Abstracts/Plugin.php` | 31 → 0 |
| `src/Api/ApiResponse.php` | 42 → 0 |
| `src/Portal/UserAccountPages.php` | 26 → 0 |

The `phpcs` scan goes from 6 files to 9, all clean.

Mostly file/class/member/function docblocks, long array syntax, single quotes, and WPCS call and parameter spacing, plus a documented `phpcs:ignore` for the portal shortcode's intentional raw HTML. Done by hand: `phpcbf` is not exposed by the workspace tooling, and most of the non-fixable violations were missing docblocks anyway.

## Reviewer notes

Two changes are behaviour-bearing rather than cosmetic. Both fell out of the sniffs, and both are worth a second pair of eyes:

* `Plugin::filter_accepted_orders()` now passes `true` to `in_array`. Every `accepted_statuses()` implementation returns an array of strings and `order_status` is always a string, and `PluginBaseTest` covers the filter.
* `ApiResponse::error()` / `success()` no longer `return` the result of `send()`, which is declared `: void`. No caller reads either value, and `send()` ends the request through `wp_send_json`.

## Base and diff noise

Cut from `security/plugin-hardening` rather than `develop`, because it needs that branch's `phpcs.xml`: `develop`'s still excludes `Hooks/` and `database/` and lacks the `WordPress.Files.FileName` severity override, without which every PSR-4 CamelCase filename trips the hyphenated-lowercase sniff.

`origin/develop` was merged in afterwards, so **`package.json` and `package-lock.json` appear in the diff purely as dependabot churn from that merge**. They are not part of this change. Both drop out once #191 merges and this retargets to `develop`.

## Deliberately excluded

`src/Data` stays excluded, with the reason inline in the ruleset. Making it clean means renaming its seven camelCase accessors to snake_case, which changes call sites in `src/Plugins/FluentCRM.php`, `src/Plugins/Autonami.php` and `ConversationSyncAllowlistTest`. That is a code change, not a formatting pass, so it belongs in its own PR. No compatibility cost — the class is unreleased.

## Remaining debt

Measured, so the next increment does not have to re-scan:

* `src/Conversations/`: 1055
* `src/Admin.php`: 636
* `src/Plugins/`: 934 across 5 files
* `src/Inboxes/`: 234
* `src/Services/`: 225
* `src/Api.php`: 190
* `src/RestRoute.php`: 174
* `src/Assistants/`: 154
* `src/Data/`: 27
* `includes/`: ~1929, mostly templates

*Roughly 5,820 of the total is `phpcbf`-fixable.*

## Testing

* `composer phpcs` clean over 9 files.
* `composer test` 141 green.
* `composer phpcompat` (PHP 7.4) clean.