### PR TITLE
fix: keep a still-valid API token working after a domain migration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,8 @@
 * fix: Knowledge base requests use the API key they are given instead of falling back to the stored one.
 * fix: Setting an order line to a quantity of zero or less returns a clear error instead of silently doing nothing.
 * fix: The FluentCRM ticket list shows each conversation's stored submission time.
+* fix: A saved API key keeps working after the site moves to a new domain. The plugin re-checks the key it already has instead of sending you back through the connect screen, and a network or server hiccup no longer marks a working key as invalid.
+* fix: An unexpected reply from the API (an error page from a proxy, an empty body) no longer breaks the settings screen.
 * dev: Removed the unused SmartPay integration and the confetti animation dependency. Hooks/ and database/ are linted under the full WordPress coding standard, and the suite covers every change above.
 
 2026-07-05 - version 2.5.0

--- a/readme.md
+++ b/readme.md
@@ -390,6 +390,8 @@ Setup takes under 5 minutes. No coding required.
 * fix: Knowledge base requests use the API key they are given instead of falling back to the stored one.
 * fix: Setting an order line to a quantity of zero or less returns a clear error instead of silently doing nothing.
 * fix: The FluentCRM ticket list shows each conversation's stored submission time.
+* fix: A saved API key keeps working after the site moves to a new domain. The plugin re-checks the key it already has instead of sending you back through the connect screen, and a network or server hiccup no longer marks a working key as invalid.
+* fix: An unexpected reply from the API (an error page from a proxy, an empty body) no longer breaks the settings screen.
 * dev: Removed the unused SmartPay integration and the confetti animation dependency. Hooks/ and database/ are linted under the full WordPress coding standard, and the suite covers every change above.
 
 = 2.5.0 =

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -2,6 +2,7 @@
 
 namespace ThriveDesk;
 use WP_Query;
+use ThriveDesk\Conversations\Conversation;
 
 // Exit if accessed directly.
 if (!defined('ABSPATH')) {
@@ -10,6 +11,13 @@ if (!defined('ABSPATH')) {
 
 final class Admin
 {
+    /**
+     * Seconds to wait on the re-verification probe in load_pages(). This one
+     * runs inside a page render, so it has to give up long before PHP's
+     * max_execution_time does.
+     */
+    private const REVERIFY_TIMEOUT = 10;
+
     /**
      * The single instance of this class
      */
@@ -225,21 +233,42 @@ final class Admin
             echo '<style>.update-nag, .updated, .error, .is-dismissible { display: none; }</style>';
         }
 
-        // Get the correct settings option where the API key is actually stored
-        $td_helpdesk_settings = get_td_helpdesk_settings();
-        $td_api_key = $td_helpdesk_settings['td_helpdesk_api_key'] ?? '';
-        
+        $td_api_key = self::stored_api_key();
+        $api_status = self::get_api_verification_status();
+
+        // Anything short of "connected" gets a second look before it is acted
+        // on, because a domain migration has two ways of faking it. The first:
+        // restoring a DB dump onto a host whose Redis/Memcached still holds the
+        // previous install's options leaves the cache disagreeing with the
+        // database. Both options are autoloaded, so they are cached under the
+        // shared 'alloptions' entry rather than their own keys - that entry is
+        // what has to go to force a fresh read.
+        if (!$td_api_key || !$api_status) {
+            wp_cache_delete('alloptions', 'options');
+
+            $td_api_key = self::stored_api_key();
+            $api_status = self::get_api_verification_status();
+        }
+
         // Essential logging only
         if (empty($td_api_key)) {
             error_log('ThriveDesk: No API key found in settings');
         }
 
-        $api_status = self::get_api_verification_status();
+        // The second: a transient network failure while DNS/SSL settle on the
+        // new domain cleared the flag on a key that still works. Ask ThriveDesk
+        // directly rather than sending the site owner through a brand new
+        // authorization. Throttled to once a minute, and on a short timeout, so
+        // a dead key or an unreachable API can't stall this page on every load.
+        if ($td_api_key && !$api_status && false === get_transient('thrivedesk_reverify_attempted')) {
+            set_transient('thrivedesk_reverify_attempted', true, MINUTE_IN_SECONDS);
+
+            if (!empty(Conversation::get_system_info($td_api_key, self::REVERIFY_TIMEOUT))) {
+                $api_status = self::get_api_verification_status();
+            }
+        }
 
         if($td_api_key && $api_status){
-            // Clear any cached options to ensure fresh data
-            wp_cache_delete('td_helpdesk_settings', 'options');
-            wp_cache_delete('td_helpdesk_verified', 'options');
             thrivedesk_view('setting');
         }
         elseif($td_api_key == '' || isset($_GET['token'])){
@@ -252,6 +281,11 @@ final class Admin
 
     public function verification_page(){
                     thrivedesk_view('pages/api-verify');
+    }
+
+    private static function stored_api_key(): string
+    {
+        return get_td_helpdesk_settings()['td_helpdesk_api_key'] ?? '';
     }
 
     public static function set_api_verification_status($status = false): void

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -147,7 +147,7 @@ class Conversation
         die();
     }
 
-    public static function get_system_info($apiKey): array
+    public static function get_system_info($apiKey, int $timeout = TDApiService::DEFAULT_TIMEOUT): array
     {
         $apiService = new TDApiService();
 
@@ -165,8 +165,8 @@ class Conversation
 		$apiService->setApiKey( $apiKey );
 
         $url = THRIVEDESK_API_URL . '/v1/me';
-    
-        $response = $apiService->getRequest($url);
+
+        $response = $apiService->getRequest($url, $timeout);
 
         if (isset($response['company'])) {
             $company = $response['company'];
@@ -190,8 +190,8 @@ class Conversation
         ) {
             wp_send_json_error( [ 'message' => __( 'Unauthorized', 'thrivedesk' ) ], 403 );
         }
-		$apiKey = $_POST['data']['td_helpdesk_api_key'] ?? '';
-        
+		$apiKey = sanitize_text_field( wp_unslash( $_POST['data']['td_helpdesk_api_key'] ?? '' ) );
+
 		if ( empty( $apiKey ) ) {
             error_log('ThriveDesk: API Key is required for verification');
 
@@ -202,8 +202,13 @@ class Conversation
 					'message' => 'API Key is required'
 				]
 			] );
-			die();
+			wp_die();
 		}
+
+        // reset_td_settings() replaces the stored key with whatever was just
+        // submitted, so the current verification status only describes the key
+        // on file for as long as the two are the same.
+        $is_same_key = $apiKey === ( get_option('td_helpdesk_settings')['td_helpdesk_api_key'] ?? '' );
 
         // save the api key to the database
         $this->reset_td_settings($apiKey);
@@ -215,7 +220,16 @@ class Conversation
 
         if ( isset( $data['wp_error'] ) && $data['wp_error'] ) {
 
-            Admin::set_api_verification_status();
+            // Only a genuine auth rejection (401/403 from the API) means the
+            // key itself is bad. A network-level failure (DNS/SSL/timeout -
+            // e.g. right after a domain migration while things are still
+            // settling) says nothing about the key, so an already-verified key
+            // keeps its status over what may well be a transient blip. A key
+            // that was just changed has never been verified, so it must not
+            // inherit the previous key's status.
+            if ( ! $is_same_key || ( $data['error_type'] ?? '' ) === 'auth' ) {
+                Admin::set_api_verification_status();
+            }
 
             error_log('ThriveDesk: API verification failed - ' . $data['message']);
 
@@ -226,7 +240,7 @@ class Conversation
                     'message' => $data['message']
                 ]
             ] );
-            die();
+            wp_die();
         }
 
         if(!isset($data['company'])){
@@ -239,11 +253,11 @@ class Conversation
 				'code' => 401,
 				'status' => 'error',
 				'data' => [
-					'message' =>  'Something went wrong: ' . $data['message']
+					'message' =>  'Something went wrong: ' . ( $data['message'] ?? '' )
 				]
 			] );
 
-			die();
+			wp_die();
         }
 
         Admin::set_api_verification_status(true);
@@ -256,7 +270,7 @@ class Conversation
             ]
         ] );
 
-        die();
+        wp_die();
 	}
 
     /**

--- a/src/Services/TDApiService.php
+++ b/src/Services/TDApiService.php
@@ -6,6 +6,13 @@ if (!defined('ABSPATH')) {
     exit;
 }
 class TDApiService {
+    /**
+     * Generous enough for the endpoints that do real work upstream. Callers
+     * that only need a liveness answer, and that run inside a page render,
+     * should pass something far shorter.
+     */
+    public const DEFAULT_TIMEOUT = 90;
+
     private $api_token;
 
     public function __construct()
@@ -28,7 +35,7 @@ class TDApiService {
         return json_decode($body, true);
     }
 
-    public function getRequest(string $url)
+    public function getRequest(string $url, int $timeout = self::DEFAULT_TIMEOUT)
     {
         $args               = [
             'headers' => [
@@ -36,7 +43,7 @@ class TDApiService {
                 'Content-Type'  => 'application/json',
                 'Accept'        => 'application/json',
             ],
-	        'timeout' => 90,
+	        'timeout' => $timeout,
         ];
 
         $response           = wp_remote_get($url, $args);
@@ -47,14 +54,24 @@ class TDApiService {
 		if ( is_wp_error( $response ) ) {
             $error_message = $response->get_error_message();
             error_log( 'ThriveDesk - API call error: ' . $error_message ); // Log the error
-            return ['wp_error' => true, 'message' => 'ThriveDesk - API call error:' . $error_message];
+            // The request never reached ThriveDesk (DNS/SSL/timeout/connection
+            // refused) - this happens transiently right after a domain
+            // migration while DNS/SSL are still settling, and says nothing
+            // about whether the stored token is valid, so callers must not
+            // treat it the same as a real auth rejection.
+            return ['wp_error' => true, 'error_type' => 'network', 'message' => 'ThriveDesk - API call error:' . $error_message];
 		} else {
             // Check the response code
             $body               = wp_remote_retrieve_body($response);
 
             if ( 200 === $response_code ) {
-                // Success: Process the response body
-                return json_decode($body, true);
+                $decoded = json_decode($body, true);
+
+                // Every caller indexes what comes back, so a body that isn't
+                // the JSON object they expect (a proxy answering with a bare
+                // string, an empty body) has to arrive as "nothing useful"
+                // rather than as something that fatals on the first offset.
+                return is_array($decoded) ? $decoded : [];
             } else {
                 error_log( 'ThriveDesk - API Request Failed. Response Code: ' . $response_code );
 
@@ -62,18 +79,30 @@ class TDApiService {
                     $body               = wp_remote_retrieve_body($response);
 
                     if (str_contains($body, 'Cloudflare')) {
-                        return ['wp_error' => true, 'message' => 'ThriveDesk - API blocked by Cloudflare. ' . $instruction_ip_whitelist];
+                        return ['wp_error' => true, 'error_type' => 'network', 'message' => 'ThriveDesk - API blocked by Cloudflare. ' . $instruction_ip_whitelist];
                     }
                 }
 
                 $body = json_decode($body, true);
 
-                return ['wp_error' => true, 'message' => 'ThriveDesk - API request failed. Response Code:' . $response_code. '. Message: '. $body['message'] ?? ''];
+                // An error body isn't always the JSON object we expect - a
+                // proxy in front of the API can answer with a bare JSON string,
+                // and indexing one of those is a fatal TypeError.
+                $api_message = is_array($body) ? ($body['message'] ?? '') : '';
+
+                // 401/403 (once the Cloudflare/WAF case above is ruled out)
+                // mean the API itself rejected the token - only this is a
+                // genuine auth failure. Anything else (5xx, etc.) is a
+                // server-side/transient problem and must not be read as
+                // "the token is invalid".
+                $error_type = in_array($response_code, [401, 403], true) ? 'auth' : 'server';
+
+                return ['wp_error' => true, 'error_type' => $error_type, 'message' => 'ThriveDesk - API request failed. Response Code:' . $response_code . '. Message: ' . $api_message];
             }
         }
 
         error_log( 'ThriveDesk - API Request Failed. Unknown error: ' . $response_code ); // Log the error
-        return ['wp_error' => true, 'message' => 'ThriveDesk - Unknown API request error. Response Code:' . $response_code];
+        return ['wp_error' => true, 'error_type' => 'server', 'message' => 'ThriveDesk - Unknown API request error. Response Code:' . $response_code];
     }
 
     public function clearAllTransients()

--- a/tests/AdminSelfHealVerificationTest.php
+++ b/tests/AdminSelfHealVerificationTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * A site that migrates to a new domain keeps its saved ThriveDesk API key in
+ * the database, but the local 'td_helpdesk_verified' flag can end up stale
+ * (a persistent object cache that wasn't flushed as part of the migration,
+ * or a transient network hiccup while DNS/SSL settle on the new domain).
+ * Admin::load_pages() must not treat that as a dead token and push the site
+ * owner through a brand new authorization when the saved key still works -
+ * it should transparently re-verify the saved key first, and must not do so
+ * on every page load once the key really is dead.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class AdminSelfHealVerificationTest extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'pre_http_request' );
+		delete_transient( 'thrivedesk_reverify_attempted' );
+
+		parent::tear_down();
+	}
+
+	private function load_pages(): string {
+		ob_start();
+		\ThriveDesk\Admin::instance()->load_pages();
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Stand in for a Redis/Memcached that carried over from the install this
+	 * site's database was imported onto: the shared autoloaded-options entry
+	 * still holds the values it had before the migration.
+	 */
+	private function prime_stale_alloptions( array $stale ): void {
+		$alloptions = wp_load_alloptions();
+
+		foreach ( $stale as $option => $value ) {
+			$alloptions[ $option ] = serialize( $value );
+		}
+
+		wp_cache_set( 'alloptions', $alloptions, 'options' );
+	}
+
+	public function test_a_stale_object_cache_cannot_hide_a_connected_install() {
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => 'DB-TOKEN' ] );
+		update_option( 'td_helpdesk_verified', true );
+		delete_transient( 'thrivedesk_reverify_attempted' );
+
+		$this->prime_stale_alloptions(
+			[
+				'td_helpdesk_settings' => [ 'td_helpdesk_api_key' => '' ],
+				'td_helpdesk_verified' => false,
+			]
+		);
+
+		// The settings screen populates itself over HTTP; keep it offline.
+		add_filter(
+			'pre_http_request',
+			static fn() => [
+				'response' => [ 'code' => 200 ],
+				'body'     => wp_json_encode( [] ),
+			]
+		);
+
+		$html = $this->load_pages();
+
+		$this->assertStringContainsString(
+			'td-api-verification-btn',
+			$html,
+			'the database says this install is connected, so it must get the settings screen, not the setup screen'
+		);
+	}
+
+	public function test_saved_key_is_silently_reverified_when_flag_is_stale() {
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => 'STILL-VALID-TOKEN' ] );
+		update_option( 'td_helpdesk_verified', false );
+		delete_transient( 'thrivedesk_reverify_attempted' );
+
+		$captured_auth = null;
+		add_filter(
+			'pre_http_request',
+			static function ( $pre, $args ) use ( &$captured_auth ) {
+				$captured_auth = $args['headers']['Authorization'] ?? null;
+
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode( [ 'company' => [ 'id' => 'c1', 'name' => 'Acme' ] ] ),
+				];
+			},
+			10,
+			2
+		);
+
+		$this->load_pages();
+
+		$this->assertSame( 'Bearer STILL-VALID-TOKEN', $captured_auth, 'the saved key must be the one re-checked against the API' );
+		$this->assertTrue( \ThriveDesk\Admin::get_api_verification_status(), 'a still-valid saved token must flip verification back on automatically' );
+	}
+
+	public function test_the_probe_gives_up_long_before_max_execution_time() {
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => 'ANY-TOKEN' ] );
+		update_option( 'td_helpdesk_verified', false );
+		delete_transient( 'thrivedesk_reverify_attempted' );
+
+		$timeout = null;
+		add_filter(
+			'pre_http_request',
+			static function ( $pre, $args ) use ( &$timeout ) {
+				$timeout = $args['timeout'] ?? null;
+
+				return new WP_Error( 'http_request_failed', 'Connection timed out' );
+			},
+			10,
+			2
+		);
+
+		$this->load_pages();
+
+		// This probe runs inside a page render, so a hung connection must not
+		// hold the settings screen past a typical 30s max_execution_time.
+		$this->assertNotNull( $timeout, 'the re-verification probe must have run' );
+		$this->assertLessThanOrEqual( 15, $timeout, 'the probe must not block the admin page on the default 90s timeout' );
+	}
+
+	public function test_reverification_is_throttled_to_once_per_minute() {
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => 'DEAD-TOKEN' ] );
+		update_option( 'td_helpdesk_verified', false );
+		delete_transient( 'thrivedesk_reverify_attempted' );
+
+		$calls = 0;
+		add_filter(
+			'pre_http_request',
+			static function ( $pre ) use ( &$calls ) {
+				$calls++;
+
+				return [
+					'response' => [ 'code' => 401 ],
+					'body'     => wp_json_encode( [ 'message' => 'Unauthenticated' ] ),
+				];
+			}
+		);
+
+		$this->load_pages();
+
+		$this->assertSame( 1, $calls, 'the first load must re-check the saved key' );
+		$this->assertNotFalse( get_transient( 'thrivedesk_reverify_attempted' ), 'the attempt must be recorded, or the throttle never closes' );
+
+		// The key is still unverified, so without that recorded attempt this
+		// would fire a live API call on every single admin page load.
+		$this->load_pages();
+
+		$this->assertSame( 1, $calls, 'a throttled retry window must not fire another live API call' );
+	}
+}

--- a/tests/ApiKeyVerificationMessageTest.php
+++ b/tests/ApiKeyVerificationMessageTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The verify handler builds its failure message out of whatever the API
+ * answered with. A 200 carrying neither company nor message data is the case
+ * that reply cannot be indexed for, and the settings screen parses this JSON -
+ * a PHP warning printed ahead of it is what the admin ends up reading.
+ *
+ * Deliberately not a TD_Ajax_TestCase: WP_Ajax_UnitTestCase turns E_WARNING
+ * off, which is the signal this test exists to catch.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class ApiKeyVerificationMessageTest extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'pre_http_request' );
+		$_POST    = [];
+		$_REQUEST = [];
+
+		parent::tear_down();
+	}
+
+	public function test_a_200_without_company_or_message_still_renders_a_clean_envelope() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => 'KEY-A' ] );
+
+		add_filter(
+			'pre_http_request',
+			static fn() => [
+				'response' => [ 'code' => 200 ],
+				'body'     => wp_json_encode( [ 'foo' => 'bar' ] ),
+			]
+		);
+
+		$_POST    = [
+			'nonce' => wp_create_nonce( 'thrivedesk-nonce' ),
+			'data'  => [ 'td_helpdesk_api_key' => 'KEY-A' ],
+		];
+		$_REQUEST = $_POST;
+
+		ob_start();
+		try {
+			\ThriveDesk\Conversations\Conversation::instance()->td_verify_helpdesk_api_key();
+		} catch ( WPDieException $e ) {
+			// wp_die() ends the handler; the JSON is already in the buffer.
+		}
+		$body = json_decode( (string) ob_get_clean(), true );
+
+		$this->assertSame( 'error', $body['status'] ?? null );
+		$this->assertSame( 'Something went wrong: ', $body['data']['message'] ?? null );
+	}
+}

--- a/tests/ApiKeyVerificationStatusTest.php
+++ b/tests/ApiKeyVerificationStatusTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * 'td_helpdesk_verified' decides whether the admin shows the settings screen or
+ * sends the site owner through a fresh authorization, so it has to describe the
+ * key actually on file. Two ways it can lie:
+ *
+ * - clearing it because the request never reached ThriveDesk (DNS/SSL/timeout,
+ *   e.g. while a new domain is still settling), which says nothing about the
+ *   key and forces a pointless re-auth;
+ * - keeping it after the admin submits a different key, which has never been
+ *   verified and must not inherit the previous key's status.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class ApiKeyVerificationStatusTest extends TD_Ajax_TestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'pre_http_request' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @param array|WP_Error $response what the HTTP layer answers with
+	 */
+	private function verify( string $submitted_key, $response ): array {
+		add_filter( 'pre_http_request', static fn() => $response );
+
+		$post = [
+			'nonce' => wp_create_nonce( 'thrivedesk-nonce' ),
+			'data'  => [ 'td_helpdesk_api_key' => $submitted_key ],
+		];
+
+		$_POST = $_REQUEST = $post;
+
+		return $this->capture_json(
+			static function () {
+				\ThriveDesk\Conversations\Conversation::instance()->td_verify_helpdesk_api_key();
+			}
+		);
+	}
+
+	private function connected_with( string $key ): void {
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => $key ] );
+		update_option( 'td_helpdesk_verified', true );
+	}
+
+	public function test_network_failure_leaves_a_verified_key_verified() {
+		$this->connected_with( 'KEY-A' );
+
+		$body = $this->verify( 'KEY-A', new WP_Error( 'http_request_failed', 'Could not resolve host' ) );
+
+		$this->assertSame( 'error', $body['status'] ?? null, 'the caller still has to be told the check failed' );
+		$this->assertTrue(
+			\ThriveDesk\Admin::get_api_verification_status(),
+			'an unreachable API says nothing about the key, so verification must survive it'
+		);
+	}
+
+	public function test_server_error_leaves_a_verified_key_verified() {
+		$this->connected_with( 'KEY-A' );
+
+		$this->verify(
+			'KEY-A',
+			[
+				'response' => [ 'code' => 500 ],
+				'body'     => wp_json_encode( [ 'message' => 'Internal Server Error' ] ),
+			]
+		);
+
+		$this->assertTrue(
+			\ThriveDesk\Admin::get_api_verification_status(),
+			'a 5xx is ThriveDesk failing, not the key being rejected'
+		);
+	}
+
+	public function test_auth_rejection_clears_verification() {
+		$this->connected_with( 'KEY-A' );
+
+		$this->verify(
+			'KEY-A',
+			[
+				'response' => [ 'code' => 401 ],
+				'body'     => wp_json_encode( [ 'message' => 'Unauthenticated' ] ),
+			]
+		);
+
+		$this->assertFalse(
+			\ThriveDesk\Admin::get_api_verification_status(),
+			'a 401 is the API rejecting the key itself, which must clear verification'
+		);
+	}
+
+	public function test_network_failure_on_a_newly_submitted_key_clears_verification() {
+		$this->connected_with( 'KEY-A' );
+
+		// The handler saves the submitted key before checking it, so KEY-B is
+		// now the key on file while KEY-A is what the flag was earned by.
+		$this->verify( 'KEY-B', new WP_Error( 'http_request_failed', 'Could not resolve host' ) );
+
+		$this->assertSame(
+			'KEY-B',
+			get_option( 'td_helpdesk_settings' )['td_helpdesk_api_key'],
+			'the submitted key replaces the stored one regardless of the outcome'
+		);
+		$this->assertFalse(
+			\ThriveDesk\Admin::get_api_verification_status(),
+			'a key that was never checked must not inherit the previous key\'s verified status'
+		);
+	}
+
+	public function test_a_200_carrying_no_company_data_is_survivable() {
+		$this->connected_with( 'KEY-A' );
+
+		// A proxy in front of the API can answer 200 with a bare JSON string,
+		// which the failure message used to be built by indexing.
+		$body = $this->verify(
+			'KEY-A',
+			[
+				'response' => [ 'code' => 200 ],
+				'body'     => wp_json_encode( 'OK' ),
+			]
+		);
+
+		$this->assertSame( 'error', $body['status'] ?? null, 'the caller still has to be told the check failed' );
+		$this->assertFalse(
+			\ThriveDesk\Admin::get_api_verification_status(),
+			'a 200 that carries no company data means the key did not authenticate'
+		);
+	}
+
+	public function test_successful_verification_sets_the_status() {
+		update_option( 'td_helpdesk_settings', [ 'td_helpdesk_api_key' => 'KEY-A' ] );
+		update_option( 'td_helpdesk_verified', false );
+
+		$body = $this->verify(
+			'KEY-B',
+			[
+				'response' => [ 'code' => 200 ],
+				'body'     => wp_json_encode( [ 'company' => [ 'id' => 'c1', 'name' => 'Acme' ] ] ),
+			]
+		);
+
+		$this->assertSame( 'success', $body['status'] ?? null );
+		$this->assertTrue( \ThriveDesk\Admin::get_api_verification_status() );
+	}
+}

--- a/tests/TDApiServiceErrorTypeTest.php
+++ b/tests/TDApiServiceErrorTypeTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * TDApiService::getRequest() must tell callers *why* a request failed.
+ * Previously every failure (DNS/SSL/timeout, an actual 401 from the API, a
+ * 5xx) was collapsed into the same generic 'wp_error' flag, so callers could
+ * not tell a transient network problem (e.g. right after a domain migration,
+ * while DNS/SSL are still settling) from a genuinely revoked/invalid token.
+ * That ambiguity is what let a still-valid saved token get treated as dead.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class TDApiServiceErrorTypeTest extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	public function test_connection_failure_is_reported_as_network() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'http_request_failed', 'Could not resolve host' );
+			}
+		);
+
+		$service = new \ThriveDesk\Services\TDApiService();
+		$service->setApiKey( 'ANY' );
+		$result = $service->getRequest( 'https://api.example.test/v1/me' );
+
+		$this->assertTrue( $result['wp_error'] );
+		$this->assertSame( 'network', $result['error_type'] );
+	}
+
+	public function test_401_response_is_reported_as_auth() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'response' => [ 'code' => 401 ],
+					'body'     => wp_json_encode( [ 'message' => 'Unauthenticated' ] ),
+				];
+			}
+		);
+
+		$service = new \ThriveDesk\Services\TDApiService();
+		$service->setApiKey( 'BAD' );
+		$result = $service->getRequest( 'https://api.example.test/v1/me' );
+
+		$this->assertTrue( $result['wp_error'] );
+		$this->assertSame( 'auth', $result['error_type'] );
+	}
+
+	public function test_an_error_body_that_is_not_a_json_object_is_survivable() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				// What a proxy in front of the API can answer with. Indexing
+				// this as if it were the usual object is a fatal TypeError.
+				return [
+					'response' => [ 'code' => 502 ],
+					'body'     => wp_json_encode( 'Bad Gateway' ),
+				];
+			}
+		);
+
+		$service = new \ThriveDesk\Services\TDApiService();
+		$service->setApiKey( 'ANY' );
+		$result = $service->getRequest( 'https://api.example.test/v1/me' );
+
+		$this->assertTrue( $result['wp_error'] );
+		$this->assertSame( 'server', $result['error_type'] );
+		$this->assertStringContainsString( '502', $result['message'] );
+	}
+
+	public function test_a_200_that_is_not_a_json_object_comes_back_as_an_array() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode( 'OK' ),
+				];
+			}
+		);
+
+		$service = new \ThriveDesk\Services\TDApiService();
+		$service->setApiKey( 'ANY' );
+		$result = $service->getRequest( 'https://api.example.test/v1/me' );
+
+		// Every caller indexes what this hands back, so a bare string reaches
+		// them as a fatal rather than as "nothing useful came back".
+		$this->assertSame( [], $result );
+	}
+
+	public function test_server_error_is_not_reported_as_auth() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'response' => [ 'code' => 500 ],
+					'body'     => wp_json_encode( [ 'message' => 'Internal Server Error' ] ),
+				];
+			}
+		);
+
+		$service = new \ThriveDesk\Services\TDApiService();
+		$service->setApiKey( 'ANY' );
+		$result = $service->getRequest( 'https://api.example.test/v1/me' );
+
+		$this->assertTrue( $result['wp_error'] );
+		$this->assertSame( 'server', $result['error_type'] );
+	}
+}


### PR DESCRIPTION
## Summary

Migrating a site to a new domain doesn't invalidate a ThriveDesk API token, but the plugin could end up stuck showing the setup/re-auth screen anyway even though the previously-saved token still works. Three gaps combined to cause this:

- `Admin::load_pages()` tried to clear the object cache for `td_helpdesk_settings` and `td_helpdesk_verified` by their own option name, but both are autoloaded options. WordPress caches those under the shared `alloptions` entry, not individually. On a site with a persistent object cache (Redis/Memcached) that wasn't flushed as part of the DB import/migration, that clear was a no-op and stale pre-migration values kept being served.
- When a saved key's local "verified" flag read `false`, the admin went straight to the "Create New Account / Connect Existing Account" welcome screen, with no attempt to recheck the key that's already on file.
- `TDApiService::getRequest()` collapsed every kind of failure (DNS/SSL/timeout, a real `401`, a `5xx`) into the same generic `wp_error` flag, so a transient network hiccup right after a domain cutover (DNS/SSL still settling) looked identical to a genuinely revoked token during manual re-verification.

## Changes

- `load_pages()` now also flushes `alloptions` so a stale persistent object cache can't mask a valid, freshly-migrated token.
- When a saved API key exists but isn't currently marked verified, `load_pages()` silently re-checks it against the ThriveDesk API (throttled to once a minute) before falling back to the setup screens, so a still-valid token keeps working with no manual re-auth needed.
- `TDApiService::getRequest()` returns an array from a 200 as well. The body isn't always the JSON object callers expect (a proxy in front of the API can answer with a bare string) and every caller indexes what it hands back, so the verify handler died with a TypeError on the settings screen instead of reporting the failure.
- `TDApiService::getRequest()` now tags failures with an `error_type` (`network` | `auth` | `server`), and `Conversation::td_verify_helpdesk_api_key()` only flips the stored verification status on a genuine `auth` (401/403) rejection, not on a network-level hiccup.

## Test plan

- [x] `php -l` on all touched files
- [x] `composer phpcs` on all touched files (clean)
- [x] Added `tests/TDApiServiceErrorTypeTest.php` covering the network/auth/server `error_type` classification
- [x] Added `tests/AdminSelfHealVerificationTest.php` covering the silent re-verification and its once-a-minute throttle
- [x] Added `tests/ApiKeyVerificationStatusTest.php` covering which failures may clear the stored verification flag, and `tests/ApiKeyVerificationMessageTest.php` covering a 200 that carries neither company nor message data
- [x] Full PHPUnit run: 157 tests green twice, PHPCS clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved admin API-key verification self-healing by re-checking stale verification state during admin page load.
  - Prevented valid keys from being marked invalid after transient network/server issues.
  - Added throttled, once-per-minute re-verification probes to reduce unnecessary requests.
  - Enhanced API error reporting with clearer authentication vs network vs server categorization.

- **Reliability**
  - Introduced configurable request timeouts for verification probes to avoid long hangs.

- **Tests**
  - Added coverage for self-healing behavior, throttling, and error-type handling across failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
