### PR TITLE
fix(portal): scope portal requests to the calling customer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 2026-07-27 - version 2.6.0
 * fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
 * fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
-* fix: The portal's reload button refreshes your own ticket list instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
+* fix: The portal's reload button refreshes the page of your own ticket list you are looking at, instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
 * fix: Order actions taken from a ThriveDesk ticket (status change, subscription cancel, quantity change, coupon, add or remove item) now verify the order belongs to the customer on that ticket before changing anything.
 * fix: Store requests are rejected when the integration has no API token or has not finished connecting, so a half-connected or disconnected store can no longer be driven.
 * fix: The connect token is generated from a cryptographic random source instead of a hashed timestamp.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2026-07-27 - version 2.6.0
 * fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
 * fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
+* fix: A ticket's messages are cached per customer, so a ticket someone else just opened is no longer shown to whoever asks for it by id. Sending a reply clears only your own cached copy instead of every customer's.
 * fix: The portal's reload button refreshes the page of your own ticket list you are looking at, instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
 * fix: Order actions taken from a ThriveDesk ticket (status change, subscription cancel, quantity change, coupon, add or remove item) now verify the order belongs to the customer on that ticket before changing anything.
 * fix: Store requests are rejected when the integration has no API token or has not finished connecting, so a half-connected or disconnected store can no longer be driven.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 *** WooCommerce Extension Changelog ***
 
 2026-07-27 - version 2.6.0
+* fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
+* fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
+* fix: The portal's reload button refreshes your own ticket list instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
 * fix: Order actions taken from a ThriveDesk ticket (status change, subscription cancel, quantity change, coupon, add or remove item) now verify the order belongs to the customer on that ticket before changing anything.
 * fix: Store requests are rejected when the integration has no API token or has not finished connecting, so a half-connected or disconnected store can no longer be driven.
 * fix: The connect token is generated from a cryptographic random source instead of a hashed timestamp.

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -274,15 +274,6 @@ if (!function_exists('remove_thrivedesk_all_cache')) {
 	}
 }
 
-if (!function_exists('remove_thrivedesk_conversation_cache')) {
-	function remove_thrivedesk_conversation_cache() {
-		global $wpdb;
-		$wpdb->query($wpdb->prepare(
-			"DELETE FROM $wpdb->options WHERE option_name LIKE %s", 
-			'_transient_thrivedesk_conversation%'));
-	}
-}
-
 /*
  * Clear cache from ajax call
  */
@@ -297,7 +288,6 @@ add_action('wp_ajax_thrivedesk_clear_cache', function () {
 
 
 	remove_thrivedesk_all_cache();
-	remove_thrivedesk_conversation_cache();
 	wp_send_json_success();
 });
 

--- a/includes/views/shortcode/conversation-details.php
+++ b/includes/views/shortcode/conversation-details.php
@@ -15,8 +15,7 @@ parse_str($parts, $query_params);
 $is_portal_available = false;
 $conversation_exists = false;
 
-$raw_conversation_id = isset($query_params['td_conversation_id']) ? (string) $query_params['td_conversation_id'] : '';
-$conversation_id = preg_match('/^[A-Za-z0-9-]{1,64}$/', $raw_conversation_id) ? $raw_conversation_id : '';
+$conversation_id = Conversation::sanitize_conversation_id($query_params['td_conversation_id'] ?? '');
 
 $is_portal_available = (new PortalService())->has_portal_access();
 

--- a/readme.md
+++ b/readme.md
@@ -376,6 +376,9 @@ Setup takes under 5 minutes. No coding required.
 
 = 2.6.0 =
 2026-07-27 - version 2.6.0
+* fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
+* fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
+* fix: The portal's reload button refreshes your own ticket list instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
 * fix: Order actions taken from a ThriveDesk ticket (status change, subscription cancel, quantity change, coupon, add or remove item) now verify the order belongs to the customer on that ticket before changing anything.
 * fix: Store requests are rejected when the integration has no API token or has not finished connecting, so a half-connected or disconnected store can no longer be driven.
 * fix: The connect token is generated from a cryptographic random source instead of a hashed timestamp.

--- a/readme.md
+++ b/readme.md
@@ -378,7 +378,7 @@ Setup takes under 5 minutes. No coding required.
 2026-07-27 - version 2.6.0
 * fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
 * fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
-* fix: The portal's reload button refreshes your own ticket list instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
+* fix: The portal's reload button refreshes the page of your own ticket list you are looking at, instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
 * fix: Order actions taken from a ThriveDesk ticket (status change, subscription cancel, quantity change, coupon, add or remove item) now verify the order belongs to the customer on that ticket before changing anything.
 * fix: Store requests are rejected when the integration has no API token or has not finished connecting, so a half-connected or disconnected store can no longer be driven.
 * fix: The connect token is generated from a cryptographic random source instead of a hashed timestamp.

--- a/readme.md
+++ b/readme.md
@@ -378,6 +378,7 @@ Setup takes under 5 minutes. No coding required.
 2026-07-27 - version 2.6.0
 * fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
 * fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
+* fix: A ticket's messages are cached per customer, so a ticket someone else just opened is no longer shown to whoever asks for it by id. Sending a reply clears only your own cached copy instead of every customer's.
 * fix: The portal's reload button refreshes the page of your own ticket list you are looking at, instead of clearing every customer's cached view, and now actually returns fresh tickets rather than the cached ones.
 * fix: Order actions taken from a ThriveDesk ticket (status change, subscription cancel, quantity change, coupon, add or remove item) now verify the order belongs to the customer on that ticket before changing anything.
 * fix: Store requests are rejected when the integration has no API token or has not finished connecting, so a half-connected or disconnected store can no longer be driven.

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -120,23 +120,14 @@ class Conversation
         }
 
         try {
-            // Clear all ThriveDesk transients
-            self::clear_all_thrivedesk_transients();
-            
-            // Get fresh conversations data
-            $conversations = self::get_conversations();
-            
-            if (!empty($conversations)) {
-                wp_send_json_success([
-                    'message' => __('Tickets reloaded successfully', 'thrivedesk'),
-                    'data' => $conversations
-                ]);
-            } else {
-                wp_send_json_success([
-                    'message' => __('Tickets reloaded successfully', 'thrivedesk'),
-                    'data' => []
-                ]);
-            }
+            // Only the caller's own cached list is dropped. This runs for any
+            // logged-in portal user, so it must not evict other customers.
+            $conversations = self::get_conversations(true);
+
+            wp_send_json_success([
+                'message' => __('Tickets reloaded successfully', 'thrivedesk'),
+                'data' => $conversations
+            ]);
         } catch (Exception $e) {
             wp_send_json_error([
                 'message' => __('Failed to reload tickets', 'thrivedesk'),
@@ -495,49 +486,44 @@ class Conversation
         );
     }
 
-    /**
-     * Clear all ThriveDesk transients to force reload
-     *
-     * @return void
-     */
-    public static function clear_all_thrivedesk_transients()
-    {
-        global $wpdb;
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-                WHERE a.option_name LIKE %s
-                AND a.option_name NOT LIKE %s
-                AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )",
-                $wpdb->esc_like( '_transient_thrivedesk_' ) . '%',
-                $wpdb->esc_like( '_transient_timeout_' ) . '%'
-            )
-        );
-    }
-
 	/**
 	 * get all conversations
 	 *
+	 * @param bool $force_refresh Drop this caller's cached page before fetching.
+	 *
 	 * @return mixed|null
 	 */
-	public static function get_conversations()
+	public static function get_conversations(bool $force_refresh = false)
 	{
         self::delete_thrivedesk_expired_transients();
-		$page               = $_GET['cv_page'] ?? 1;
+		$page               = max(1, absint($_GET['cv_page'] ?? 1));
 		$current_user_email = wp_get_current_user()->user_email;
 		$inbox_id           = get_option('td_helpdesk_settings')['td_helpdesk_inbox_id'] ?? '';
-		
+
 		// get data from cache - include inbox_id in cache key for proper filtering
 		$cache_key = 'thrivedesk_conversations_' . $page . '_' . $current_user_email . '_' . $inbox_id;
+
+		if ($force_refresh) {
+			delete_transient($cache_key);
+		}
+
 		$data = get_transient($cache_key);
 
 		if (!$data) {
-			$url = THRIVEDESK_API_URL . self::TD_CONVERSATION_URL . '?customer_email=' . $current_user_email . '&page=' . $page . '&per-page=15';
-			
+			$query = [
+				'customer_email' => $current_user_email,
+				'page'           => $page,
+				'per-page'       => 15,
+			];
+
 			// Add inbox filtering if inbox is selected
 			if (!empty($inbox_id)) {
-				$url .= '&inbox_id=' . $inbox_id;
+				$query['inbox_id'] = $inbox_id;
 			}
+
+			// http_build_query encodes every value, so nothing carried in on the
+			// request can close one parameter and open a customer_email of its own.
+			$url = THRIVEDESK_API_URL . self::TD_CONVERSATION_URL . '?' . http_build_query($query);
 
 			$response =( new TDApiService() )->getRequest($url);
 
@@ -555,6 +541,22 @@ class Conversation
 	}
 
 	/**
+	 * A conversation id lands in the path of an authenticated API call, so a
+	 * value carrying a slash or a query separator would repoint that call.
+	 * Anything outside the id alphabet is rejected rather than escaped.
+	 *
+	 * @param mixed $raw
+	 *
+	 * @return string Empty when the id is unusable.
+	 */
+	public static function sanitize_conversation_id($raw): string
+	{
+		$id = is_scalar($raw) ? (string) $raw : '';
+
+		return preg_match('/^[A-Za-z0-9-]{1,64}$/', $id) ? $id : '';
+	}
+
+	/**
 	 * get single conversation
 	 *
 	 * @param $conversation_id
@@ -563,7 +565,9 @@ class Conversation
 	 */
 	public static function get_conversation($conversation_id)
 	{
-		if (!$conversation_id) {
+		$conversation_id = self::sanitize_conversation_id($conversation_id);
+
+		if ('' === $conversation_id) {
 			return null;
 		}
 
@@ -571,7 +575,7 @@ class Conversation
 
 		if (!$response) {
 			$current_user_email = wp_get_current_user()->user_email;
-			$url      = THRIVEDESK_API_URL . self::TD_CONVERSATION_URL . $conversation_id .'?customer_email=' . $current_user_email;
+			$url      = THRIVEDESK_API_URL . self::TD_CONVERSATION_URL . $conversation_id .'?customer_email=' . rawurlencode($current_user_email);
 			$response =( new TDApiService() )->getRequest($url);
 
 			// 30s TTL: the cache exists only to absorb rapid page reloads on
@@ -612,12 +616,18 @@ class Conversation
             || !isset($_POST['data']['conversation_id'])
             || !isset($_POST['data']['reply_text'])
             || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['data']['nonce'])), 'td-reply-conversation-action')) {
-            die;
+            wp_die();
+        }
+
+        $conversation_id = self::sanitize_conversation_id($_POST['data']['conversation_id']);
+
+        if ('' === $conversation_id) {
+            wp_die();
         }
 
 		$current_user_email = wp_get_current_user()->user_email;
 
-        $url      = THRIVEDESK_API_URL . self::TD_CONVERSATION_URL . $_POST['data']['conversation_id'] . '/reply?customer_email=' . $current_user_email;
+        $url      = THRIVEDESK_API_URL . self::TD_CONVERSATION_URL . $conversation_id . '/reply?customer_email=' . rawurlencode($current_user_email);
 
         $data = [
             'message' => stripslashes($_POST['data']['reply_text']),
@@ -637,7 +647,7 @@ class Conversation
         }catch (\Exception $e) {
             echo wp_json_encode(['status' => 'error', 'message' => $e->getMessage()]);
         }
-        die;
+        wp_die();
     }
 
     public static function td_conversation_sort_by_status($data)

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -576,6 +576,18 @@ class Conversation
 	}
 
 	/**
+	 * Nothing here decides who may read a conversation - the API does, from the
+	 * customer_email on the request. A cache hit returns before that request is
+	 * made, so the reader belongs in the key just as it does for the list
+	 * above; without it the next reader is served whatever the last one was
+	 * allowed to see.
+	 */
+	private static function conversation_cache_key(string $conversation_id): string
+	{
+		return 'thrivedesk_conversation_' . $conversation_id . '_' . wp_get_current_user()->user_email;
+	}
+
+	/**
 	 * get single conversation
 	 *
 	 * @param $conversation_id
@@ -590,7 +602,8 @@ class Conversation
 			return null;
 		}
 
-		$response = get_transient('thrivedesk_conversation_' . $conversation_id);
+		$cache_key = self::conversation_cache_key($conversation_id);
+		$response  = get_transient($cache_key);
 
 		if (!$response) {
 			$current_user_email = wp_get_current_user()->user_email;
@@ -600,13 +613,13 @@ class Conversation
 			// 30s TTL: the cache exists only to absorb rapid page reloads on
 			// the same conversation. A longer window hides agent replies
 			// (ThriveDesk doesn't notify WP when an agent sends a message,
-			// and the cache is only invalidated when the customer replies
-			// see td_send_reply -> remove_thrivedesk_conversation_cache).
+			// and the only explicit invalidation is the customer's own reply
+			// in td_send_reply).
 			if (isset($response['data'])) {
-				set_transient('thrivedesk_conversation_' . $conversation_id, $response, 30);
+				set_transient($cache_key, $response, 30);
 			} elseif (is_array($response) && !isset($response['wp_error'])) {
 				// If API returns data directly (not wrapped in 'data' key)
-				set_transient('thrivedesk_conversation_' . $conversation_id, $response, 30);
+				set_transient($cache_key, $response, 30);
 			}
 		}
 
@@ -657,7 +670,9 @@ class Conversation
         try {
             $response_body =( new TDApiService() )->postRequest($url, $data);
 
-	        remove_thrivedesk_conversation_cache();
+            // The reply invalidates this customer's view of this conversation
+            // and nothing else. Anyone else's cached copy is theirs to keep.
+            delete_transient(self::conversation_cache_key($conversation_id));
 
             echo wp_json_encode([
                 'status'  => 'success',

--- a/src/Conversations/Conversation.php
+++ b/src/Conversations/Conversation.php
@@ -122,13 +122,13 @@ class Conversation
         try {
             // Only the caller's own cached list is dropped. This runs for any
             // logged-in portal user, so it must not evict other customers.
-            $conversations = self::get_conversations(true);
+            $conversations = self::get_conversations(true, self::referred_page());
 
             wp_send_json_success([
                 'message' => __('Tickets reloaded successfully', 'thrivedesk'),
                 'data' => $conversations
             ]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             wp_send_json_error([
                 'message' => __('Failed to reload tickets', 'thrivedesk'),
                 'error' => $e->getMessage()
@@ -136,6 +136,25 @@ class Conversation
         }
         
         die();
+    }
+
+    /**
+     * The page the caller is looking at. admin-ajax carries none of the portal
+     * page's query string, so it comes from the URL they clicked Reload on.
+     * wp_get_referer() rejects anything off-site, and an absent one leaves the
+     * first page rather than a guess.
+     */
+    private static function referred_page(): int
+    {
+        $referer = wp_get_referer();
+
+        if (!$referer) {
+            return 1;
+        }
+
+        parse_str((string) wp_parse_url($referer, PHP_URL_QUERY), $query);
+
+        return max(1, absint($query['cv_page'] ?? 1));
     }
 
     public static function get_system_info($apiKey): array
@@ -489,14 +508,15 @@ class Conversation
 	/**
 	 * get all conversations
 	 *
-	 * @param bool $force_refresh Drop this caller's cached page before fetching.
+	 * @param bool     $force_refresh Drop this caller's cached page before fetching.
+	 * @param int|null $page          Page to fetch. Defaults to the one in the URL.
 	 *
 	 * @return mixed|null
 	 */
-	public static function get_conversations(bool $force_refresh = false)
+	public static function get_conversations(bool $force_refresh = false, ?int $page = null)
 	{
         self::delete_thrivedesk_expired_transients();
-		$page               = max(1, absint($_GET['cv_page'] ?? 1));
+		$page               = max(1, $page ?? absint($_GET['cv_page'] ?? 1));
 		$current_user_email = wp_get_current_user()->user_email;
 		$inbox_id           = get_option('td_helpdesk_settings')['td_helpdesk_inbox_id'] ?? '';
 
@@ -533,7 +553,6 @@ class Conversation
 				// doesn't notify WP on agent activity, so the cache exists only
 				// to absorb rapid reloads, not to "hide" updates.
 				set_transient($cache_key, $response, 30);
-				set_transient('thrivedesk_conversations_total_pages', $response['meta']['last_page'], 30);
 			}
 		}
 

--- a/src/Services/TDApiService.php
+++ b/src/Services/TDApiService.php
@@ -79,7 +79,6 @@ class TDApiService {
     public function clearAllTransients()
     {
         delete_transient('thrivedesk_assistants');
-        delete_transient('thrivedesk_conversations_total_pages');
         delete_transient('thrivedesk_portal_access');
     }
 

--- a/tests/ConversationCacheScopeTest.php
+++ b/tests/ConversationCacheScopeTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Nothing in the plugin decides who may read a conversation - the API does,
+ * from the customer_email on the request. A cache hit returns before that
+ * request is made, so a cached copy keyed on the conversation id alone hands
+ * the next reader whatever the previous one was allowed to see. The reader is
+ * part of the identity of the cached copy, exactly as it is for the list.
+ *
+ * The reply path has the mirror obligation: it invalidates on behalf of one
+ * customer, so it must not evict anybody else's cached conversation or list.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class ConversationCacheScopeTest extends TD_Ajax_TestCase {
+
+	/** @var string[] Outbound request URLs captured during the test. */
+	private $requests = [];
+
+	/** @var array<string,int> Subscriber id per email, so switching back reuses the account. */
+	private $users = [];
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->requests = [];
+		$this->users    = [];
+
+		// Answer with the customer_email the request carried, so a response
+		// served to the wrong reader is visible in the returned payload rather
+		// than only in the request count.
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) {
+				$this->requests[] = $url;
+
+				parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode(
+						[
+							'data' => [
+								'id'       => 'conv-1',
+								'read_for' => $query['customer_email'] ?? '',
+							],
+							'message' => 'ok',
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+	}
+
+	private function login_subscriber( string $email ): void {
+		if ( ! isset( $this->users[ $email ] ) ) {
+			$this->users[ $email ] = self::factory()->user->create(
+				[
+					'role'       => 'subscriber',
+					'user_email' => $email,
+				]
+			);
+		}
+
+		wp_set_current_user( $this->users[ $email ] );
+	}
+
+	/** Reads only, so the reply POST doesn't distort the count. */
+	private function read_count(): int {
+		return count(
+			array_filter(
+				$this->requests,
+				static function ( $url ) {
+					return false === strpos( $url, '/reply?' );
+				}
+			)
+		);
+	}
+
+	private function reply_to( string $conversation_id ): void {
+		$this->capture_json(
+			function () use ( $conversation_id ) {
+				$_POST    = [
+					'data' => [
+						'nonce'           => wp_create_nonce( 'td-reply-conversation-action' ),
+						'conversation_id' => $conversation_id,
+						'reply_text'      => 'hello',
+					],
+				];
+				$_REQUEST = $_POST;
+
+				\ThriveDesk\Conversations\Conversation::instance()->td_send_reply();
+			}
+		);
+	}
+
+	public function test_a_cached_conversation_is_not_served_to_another_customer() {
+		$this->login_subscriber( 'owner@example.com' );
+		$owner_view = \ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+		$this->assertSame( 'owner@example.com', $owner_view['read_for'] ?? null );
+
+		$this->login_subscriber( 'nosy@example.com' );
+		$nosy_view = \ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+
+		$this->assertSame(
+			2,
+			$this->read_count(),
+			'a second reader must reach the API, which is the only thing that checks ownership'
+		);
+		$this->assertSame(
+			'nosy@example.com',
+			$nosy_view['read_for'] ?? null,
+			"a cached copy must never be handed to a customer it was not fetched for"
+		);
+	}
+
+	public function test_the_same_customer_still_gets_a_cached_copy() {
+		$this->login_subscriber( 'owner@example.com' );
+
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+
+		$this->assertSame( 1, $this->read_count(), 'the cache must still absorb a repeat read' );
+	}
+
+	public function test_a_reply_drops_the_callers_own_cached_conversation() {
+		$this->login_subscriber( 'owner@example.com' );
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+
+		$this->reply_to( 'conv-1' );
+
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+
+		$this->assertSame(
+			2,
+			$this->read_count(),
+			"the reply changed the thread, so the replier's own copy must be refetched"
+		);
+	}
+
+	public function test_a_reply_leaves_another_customers_cached_conversation_alone() {
+		$this->login_subscriber( 'other@example.com' );
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+
+		$this->login_subscriber( 'owner@example.com' );
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+		$this->reply_to( 'conv-1' );
+
+		$this->login_subscriber( 'other@example.com' );
+		\ThriveDesk\Conversations\Conversation::get_conversation( 'conv-1' );
+
+		$this->assertSame(
+			2,
+			$this->read_count(),
+			"one customer's reply must not evict another customer's cached conversation"
+		);
+	}
+
+	public function test_a_reply_leaves_another_customers_cached_list_alone() {
+		$other_list = 'thrivedesk_conversations_1_other@example.com_';
+		set_transient( $other_list, [ 'data' => [ [ 'id' => 'theirs' ] ] ], 300 );
+
+		$this->login_subscriber( 'owner@example.com' );
+		$this->reply_to( 'conv-1' );
+
+		// Read past the in-process option cache: a raw DELETE removes the row
+		// while leaving the cached copy behind, which hides the eviction here.
+		wp_cache_flush();
+
+		$this->assertNotFalse(
+			get_transient( $other_list ),
+			"a reply must not reach another customer's cached ticket list"
+		);
+	}
+}

--- a/tests/ConversationRequestScopingTest.php
+++ b/tests/ConversationRequestScopingTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Portal input reaches ThriveDesk as a URL, and TDApiService always attaches the
+ * site's API key, so whatever the visitor controls must be bounded before it
+ * lands there. A raw page number can append a second customer_email and take
+ * over the customer scope; a raw conversation id can repoint the path of an
+ * authenticated call.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class ConversationRequestScopingTest extends TD_Ajax_TestCase {
+
+	/** @var string[] Outbound request URLs captured during the test. */
+	private $requests = [];
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->requests = [];
+
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) {
+				$this->requests[] = $url;
+
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode(
+						[
+							'data' => [ [ 'id' => 'abc' ] ],
+							'meta' => [ 'last_page' => 1 ],
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+	}
+
+	public function tear_down() {
+		unset( $_GET['cv_page'] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Resolve the query of the first captured request the way a server would:
+	 * parse_str keeps the last occurrence of a repeated key.
+	 */
+	private function first_request_query(): array {
+		$this->assertNotEmpty( $this->requests, 'expected an outbound request' );
+		parse_str( (string) wp_parse_url( $this->requests[0], PHP_URL_QUERY ), $query );
+
+		return $query;
+	}
+
+	private function login_subscriber( string $email ): void {
+		wp_set_current_user(
+			self::factory()->user->create(
+				[
+					'role'       => 'subscriber',
+					'user_email' => $email,
+				]
+			)
+		);
+	}
+
+	public function test_cv_page_cannot_inject_another_customer_email() {
+		$this->login_subscriber( 'me@example.com' );
+
+		$_GET['cv_page'] = '1&customer_email=victim@example.com';
+
+		\ThriveDesk\Conversations\Conversation::get_conversations();
+
+		$query = $this->first_request_query();
+		$this->assertSame( 'me@example.com', $query['customer_email'] );
+	}
+
+	public function test_cv_page_reaches_the_api_as_digits_only() {
+		$this->login_subscriber( 'me@example.com' );
+
+		$_GET['cv_page'] = '2 and some junk';
+
+		\ThriveDesk\Conversations\Conversation::get_conversations();
+
+		$query = $this->first_request_query();
+		$this->assertSame( '2', $query['page'] );
+	}
+
+	public function test_reply_rejects_a_conversation_id_that_repoints_the_request() {
+		$this->login_subscriber( 'me@example.com' );
+
+		$this->capture_json(
+			function () {
+				$_POST    = [
+					'data' => [
+						'nonce'           => wp_create_nonce( 'td-reply-conversation-action' ),
+						'conversation_id' => '1/../../v1/me?leak=',
+						'reply_text'      => 'hello',
+					],
+				];
+				$_REQUEST = $_POST;
+
+				\ThriveDesk\Conversations\Conversation::instance()->td_send_reply();
+			}
+		);
+
+		$this->assertSame( [], $this->requests, 'an unusable id must not reach the API' );
+	}
+
+	public function test_reply_still_sends_a_well_formed_conversation_id() {
+		$this->login_subscriber( 'me@example.com' );
+
+		$body = $this->capture_json(
+			function () {
+				$_POST    = [
+					'data' => [
+						'nonce'           => wp_create_nonce( 'td-reply-conversation-action' ),
+						'conversation_id' => 'abc-123',
+						'reply_text'      => 'hello',
+					],
+				];
+				$_REQUEST = $_POST;
+
+				\ThriveDesk\Conversations\Conversation::instance()->td_send_reply();
+			}
+		);
+
+		$this->assertCount( 1, $this->requests );
+		$this->assertStringContainsString( '/abc-123/reply', $this->requests[0] );
+		// The portal JS branches on response.status, so the envelope must survive
+		// the switch from a bare die to wp_die().
+		$this->assertSame( 'success', $body['status'] ?? null );
+	}
+
+	public function test_get_conversation_rejects_an_unusable_id() {
+		$this->login_subscriber( 'me@example.com' );
+
+		$this->assertNull( \ThriveDesk\Conversations\Conversation::get_conversation( '1/../../v1/me' ) );
+		$this->assertSame( [], $this->requests, 'an unusable id must not reach the API' );
+	}
+}

--- a/tests/ReloadTicketsCacheScopeTest.php
+++ b/tests/ReloadTicketsCacheScopeTest.php
@@ -3,26 +3,33 @@
  * td_reload_tickets is a portal action open to every logged-in user, so it must
  * refresh the caller's own ticket list and nothing else. It used to wipe the
  * whole plugin cache with a direct DELETE, which both evicted every other
- * customer's cached conversations and — because a raw query leaves WordPress's
- * option cache untouched — still served the caller their stale list.
+ * customer's cached conversations and (because a raw query leaves WordPress's
+ * option cache untouched) still served the caller their stale list.
  *
  * @package ThriveDesk\Tests
  */
 
 class ReloadTicketsCacheScopeTest extends TD_Ajax_TestCase {
 
+	/** @var string[] Outbound request URLs captured during the test. */
+	private $requests = [];
+
 	public function set_up() {
 		parent::set_up();
 
+		$this->requests = [];
+
 		add_filter(
 			'pre_http_request',
-			static function () {
+			function ( $pre, $args, $url ) {
+				$this->requests[] = $url;
+
 				return [
 					'response' => [ 'code' => 200 ],
 					'body'     => wp_json_encode(
 						[
 							'data' => [ [ 'id' => 'fresh' ] ],
-							'meta' => [ 'last_page' => 1 ],
+							'meta' => [ 'last_page' => 3 ],
 						]
 					),
 				];
@@ -30,6 +37,12 @@ class ReloadTicketsCacheScopeTest extends TD_Ajax_TestCase {
 			10,
 			3
 		);
+	}
+
+	public function tear_down() {
+		unset( $_SERVER['HTTP_REFERER'] );
+
+		parent::tear_down();
 	}
 
 	private function login_subscriber( string $email ): void {
@@ -82,5 +95,62 @@ class ReloadTicketsCacheScopeTest extends TD_Ajax_TestCase {
 		$body = $this->reload();
 
 		$this->assertSame( 'fresh', $body['data']['data']['data'][0]['id'] ?? null );
+	}
+
+	/**
+	 * The button posts to admin-ajax, which carries none of the portal page's
+	 * query string, so page 1 is all the handler can infer on its own. A
+	 * customer paging through their tickets would get the reload they asked
+	 * for on a page they aren't looking at.
+	 */
+	public function test_reload_refreshes_the_page_the_customer_is_viewing() {
+		$this->login_subscriber( 'me@example.com' );
+
+		set_transient(
+			'thrivedesk_conversations_2_me@example.com_',
+			[ 'data' => [ [ 'id' => 'stale' ] ] ],
+			300
+		);
+
+		$_SERVER['HTTP_REFERER'] = home_url( '/support/?cv_page=2' );
+
+		$this->reload();
+
+		parse_str( (string) wp_parse_url( $this->requests[0] ?? '', PHP_URL_QUERY ), $query );
+		$this->assertSame( '2', $query['page'] ?? null, 'the refetch must ask for the page being viewed' );
+
+		$cached = get_transient( 'thrivedesk_conversations_2_me@example.com_' );
+		$this->assertSame( 'fresh', $cached['data'][0]['id'] ?? null, 'the viewed page is the one that must be dropped and refetched' );
+	}
+
+	public function test_an_offsite_referer_falls_back_to_the_first_page() {
+		$this->login_subscriber( 'me@example.com' );
+
+		$_SERVER['HTTP_REFERER'] = 'https://elsewhere.example/?cv_page=9';
+
+		$this->reload();
+
+		parse_str( (string) wp_parse_url( $this->requests[0] ?? '', PHP_URL_QUERY ), $query );
+		$this->assertSame( '1', $query['page'] ?? null );
+	}
+
+	public function test_a_failing_fetch_is_reported_instead_of_taking_the_request_down() {
+		$this->login_subscriber( 'me@example.com' );
+
+		// Stands in for anything under get_conversations() throwing. The catch
+		// named an Exception that resolved into this namespace, so it matched
+		// nothing and the handler died instead of answering.
+		add_filter(
+			'pre_http_request',
+			static function () {
+				throw new \Exception( 'boom' );
+			},
+			9
+		);
+
+		$body = $this->reload();
+
+		$this->assertFalse( $body['success'] ?? null );
+		$this->assertSame( 'Failed to reload tickets', $body['data']['message'] ?? null );
 	}
 }

--- a/tests/ReloadTicketsCacheScopeTest.php
+++ b/tests/ReloadTicketsCacheScopeTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * td_reload_tickets is a portal action open to every logged-in user, so it must
+ * refresh the caller's own ticket list and nothing else. It used to wipe the
+ * whole plugin cache with a direct DELETE, which both evicted every other
+ * customer's cached conversations and — because a raw query leaves WordPress's
+ * option cache untouched — still served the caller their stale list.
+ *
+ * @package ThriveDesk\Tests
+ */
+
+class ReloadTicketsCacheScopeTest extends TD_Ajax_TestCase {
+
+	public function set_up() {
+		parent::set_up();
+
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'response' => [ 'code' => 200 ],
+					'body'     => wp_json_encode(
+						[
+							'data' => [ [ 'id' => 'fresh' ] ],
+							'meta' => [ 'last_page' => 1 ],
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+	}
+
+	private function login_subscriber( string $email ): void {
+		wp_set_current_user(
+			self::factory()->user->create(
+				[
+					'role'       => 'subscriber',
+					'user_email' => $email,
+				]
+			)
+		);
+	}
+
+	private function reload(): array {
+		return $this->capture_json(
+			function () {
+				$_POST    = [ 'nonce' => wp_create_nonce( 'thrivedesk-nonce' ) ];
+				$_REQUEST = $_POST;
+
+				\ThriveDesk\Conversations\Conversation::instance()->td_reload_tickets();
+			}
+		);
+	}
+
+	public function test_reload_leaves_another_customers_cache_alone() {
+		$other_key = 'thrivedesk_conversations_1_other@example.com_';
+		set_transient( $other_key, [ 'data' => [ [ 'id' => 'theirs' ] ] ], 300 );
+
+		$this->login_subscriber( 'me@example.com' );
+
+		$body = $this->reload();
+		$this->assertSame( true, $body['success'] ?? null, 'reload must succeed for a portal user' );
+
+		// Read past the in-process option cache: the old blanket DELETE removed
+		// the row while leaving the cached copy behind.
+		wp_cache_flush();
+
+		$this->assertNotFalse( get_transient( $other_key ), "another customer's cached list must survive" );
+	}
+
+	public function test_reload_serves_the_caller_fresh_data() {
+		$this->login_subscriber( 'me@example.com' );
+
+		set_transient(
+			'thrivedesk_conversations_1_me@example.com_',
+			[ 'data' => [ [ 'id' => 'stale' ] ] ],
+			300
+		);
+
+		$body = $this->reload();
+
+		$this->assertSame( 'fresh', $body['data']['data']['data'][0]['id'] ?? null );
+	}
+}


### PR DESCRIPTION
## Summary

Every portal request the plugin makes carries the site's ThriveDesk API key, and the API decides who may read what from the `customer_email` on the request. Nothing in the plugin checks ownership itself. That makes three things load-bearing: the email has to be the caller's, the visitor must not be able to steer the URL, and a cached answer must never outlive the reader it was fetched for. None of the three held.

> [!WARNING]
> `get_conversations()` built its URL as `?customer_email=<caller>&page=<raw cv_page>`, with the page number concatenated **after** the email. A `cv_page` of `1&customer_email=victim@example.com` appended a second copy, and duplicate query keys resolve last-wins, so the API looked up the victim. Any logged-in subscriber could read any customer's ticket list.

## Changes

| Area | Before | After |
| --- | --- | --- |
| `get_conversations()` | Raw `cv_page` concatenated after `customer_email` | `absint()` plus `http_build_query()`, so no value can close one parameter and open another |
| `get_conversation()` | Cached on the conversation id alone | Cache key includes the reader, so a cached thread is never served to a different customer |
| `td_send_reply()` | Raw `conversation_id` in the path of an authenticated call | Validated by `sanitize_conversation_id()` before the request is built |
| `td_reload_tickets()` | Blanket `DELETE` over every ThriveDesk transient | Drops the caller's own page and refetches it |

`add_query_arg()` would not have closed the first one. It does not encode its values.

### Request scoping

`sanitize_conversation_id()` centralises the `[A-Za-z0-9-]{1,64}` check that previously lived in `conversation-details.php`. Both `get_conversation()` and `td_send_reply()` apply it themselves, so neither depends on its caller having validated the id first. The id lands in the **path** of a request carrying the API key, so a value with a slash or a query separator would repoint that request.

### Cache scoping

A cache hit returns before the API call, and that call is the only ownership check. Keying `get_conversation()` on the id alone meant that for the 30s TTL, any logged-in customer could read a conversation another had just opened, with the API never seeing their email. The reader is now part of the key, as it already was for the list.

`td_send_reply()` invalidated with a raw `DELETE ... LIKE '_transient_thrivedesk_conversation%'`, which also matched the per-customer `thrivedesk_conversations_<page>_<email>_<inbox>` list keys. One customer's reply evicted every customer's cache. It now drops the single key it owns. `remove_thrivedesk_conversation_cache()` is gone: the admin clear-cache path it also served is already covered by `remove_thrivedesk_all_cache()`, whose `'_transient_thrivedesk_%'` pattern matches the conversation keys.

### Reload correctness

`td_reload_tickets()` posts to `admin-ajax`, which carries none of the portal page's query string, so the handler computed page 1 and dropped only that key. A customer on `?cv_page=2` got the reload they asked for on a page they were not looking at, and the `location.reload()` that follows served them the surviving page-2 transient. The page now comes from `wp_get_referer()`, which rejects an off-site referer and falls back to the first page when there is none.

The `catch` in that handler named `Exception` unqualified inside `namespace ThriveDesk\Conversations`, so it resolved to a class that does not exist and matched nothing. Anything thrown under `get_conversations()` took the request down instead of returning the error envelope the portal JS expects.

`thrivedesk_conversations_total_pages` was written on every list fetch and deleted on every key change, and read nowhere. The paginator builds itself from the response's `meta.links`. Both ends dropped.

### Testability

The bare `die` calls in `td_send_reply()` become `wp_die()` so the handler is reachable from the suite. This is not a behaviour change in production: the portal JS uses `jQuery.post` with no `dataType`, so the request carries `Accept: */*`, `wp_is_json_request()` is false, and `wp_die()` routes to `_ajax_wp_die_handler`, which defaults to a 200 and dies with an empty body. The JSON envelope the JS branches on is unchanged.

## Test plan

- [x] `tests/ConversationRequestScopingTest.php` covers `cv_page` injection, page coercion, and conversation id rejection on both the reply and read paths
- [x] `tests/ConversationCacheScopeTest.php` covers per-reader cache identity, that a repeat read still hits cache, and that a reply evicts only the caller's own conversation and no other customer's list
- [x] `tests/ReloadTicketsCacheScopeTest.php` covers cache scoping, fresh data, the viewed page, the off-site referer fallback, and the error envelope
- [x] Full suite green twice on the merged result: **172 tests, 319 assertions, 8 skipped** (the skips are WPSubscription, unrelated)
- [x] PHPCS clean
- [x] CI green on PHP 7.4 and 8.4

The cache tests were written before the fix and failed 4 of 5 against the old code. The first one made a single HTTP request for two different customers, which is the leak itself.

## Notes for review

`develop` is merged in (`7d583ac`). The one conflict was in `get_system_info()`, where #198 added a `$timeout` parameter and this branch inserted `referred_page()` immediately above it. Both sides are kept. The parameter is required, not cosmetic: the merged function body calls `getRequest($url, $timeout)`.

Follow-ups, deliberately not in this PR:

- The reload page is inferred from `wp_get_referer()`. A stripped `Referer` silently reloads page 1 for someone on page 2. The page is known client-side, so `conversation.js` could post it.
- Both cache keys embed the raw email, so `_transient_` plus the key can exceed `wp_options.option_name`'s 191 characters for a pathological address. On MySQL strict mode the write errors and the transient is simply not set, which degrades caching without collisions. Non-strict hosts would truncate. Worth hashing the email in **both** keys at once rather than half of it here.
- `remove_thrivedesk_all_cache()` is still a raw query that leaves WordPress's option cache intact, so the admin Clear Cache button does not fully take effect behind a persistent object cache. Admin-only, so low severity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated conversation/ticket reload to refresh only the currently viewing customer’s data and return fresh results (even when empty).
  * Tightened validation and sanitization of conversation identifiers so malformed inputs fail safely and never reach the remote service.
  * Improved request parameter handling and cache scoping for safer, more reliable API communication.
  * Adjusted transient clearing to avoid unnecessary invalidation of cached conversation pagination totals.
* **Tests**
  * Added coverage for cache scoping and request sanitization for conversation and reload endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
