### PR TITLE
test(e2e): add a Playwright suite for the admin screens and portal

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -33,6 +33,10 @@ phpunit.xml
 phpunit.xml.dist
 .phpunit.result.cache
 tests/
+/e2e
+playwright.config.ts
+playwright-report/
+test-results/
 .travis.yml
 .circleci/
 .codeclimate.yml

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ svn
 # Testing #
 ##########
 .phpunit.result.cache
+playwright-report/
+test-results/
+e2e/.auth/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,86 @@
+# Browser tests
+
+Playwright specs that drive the plugin the way a site owner does: the admin
+screens under `wp-admin`, and the portal shortcode on the front end.
+
+They run against a **real WordPress with this plugin active and connected to a
+ThriveDesk account** — there is no fixture site and nothing is stubbed. Point
+them at a local install, a staging site, or a throwaway box; the suite only
+needs the URL and two logins.
+
+## Running
+
+```
+npm install
+npx playwright install chromium   # skip if the browsers are already present
+
+WP_BASE_URL=https://example.test \
+WP_ADMIN_USER=admin WP_ADMIN_PASSWORD=... \
+WP_CUSTOMER_USER=shopper WP_CUSTOMER_PASSWORD=... \
+npm run e2e
+```
+
+`npm run e2e:ui` opens the Playwright UI runner instead.
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `WP_BASE_URL` | yes | Site root, no trailing slash |
+| `WP_ADMIN_USER` / `WP_ADMIN_PASSWORD` | yes | An account with `manage_options` |
+| `WP_CUSTOMER_USER` / `WP_CUSTOMER_PASSWORD` | yes | A customer with at least one ThriveDesk ticket |
+| `WP_PORTAL_PATH` | no | Path of the page holding `[thrivedesk_portal]` (default `/thrivedesk-support-portal/`) |
+
+## What the site needs
+
+- The plugin connected to a ThriveDesk account, with at least one assistant and
+  one inbox on that account.
+- A published page containing the `[thrivedesk_portal]` shortcode.
+- The customer account's email matching a ThriveDesk contact that has tickets —
+  without one there is nothing for the portal to list.
+- WooCommerce active, for the connect-handshake spec.
+
+The portal specs skip themselves, with a reason, on an account whose plan does
+not include the WP Portal.
+
+## Writing specs
+
+- **The suite runs serially and shares one site.** Anything a spec changes it
+  changes for every spec after it, so put back what you touch — see
+  `helpers/connection.ts`, which captures the whole settings form and restores
+  it through the same controls a person would use.
+- **Verification is destructive.** Submitting a key stores it before checking
+  it, and storing it clears the assistant, inbox and knowledge base. Any spec
+  that verifies has to restore.
+- **Prefer the ids already in the markup** (`#td_helpdesk_api_key`,
+  `#td-assistants`, `#td_setting_btn_submit`, `button.connect[data-plugin]`)
+  over adding new hooks.
+- **Assertions go through the UI.** A spec that reaches around the interface to
+  make its assertions stops describing what a user can do. Teardown is the one
+  exception — `helpers/connection.ts` posts to the plugin's own admin-ajax
+  actions, for the reason below.
+- **Normalise state you depend on; don't assume it.** An integration's button is
+  Connect or Disconnect depending on stored state, and each posts a different
+  action — so a spec that assumes one silently drives the other and then waits for
+  a response that never comes. Seeded sites can arrive either way. See
+  `disconnected()` in `woocommerce-connect.e2e.ts`.
+- **When a click-plus-wait times out, log the requests before blaming the click.**
+  `Promise.all([waitFor…, click])` reports the *sibling* promise's timeout, so the
+  error names the wait and every artifact shows a healthy page with an enabled
+  button.
+- **A rendered button is not a working button.** Every handler in `admin.js` is
+  registered in one jQuery ready callback, and that bundle carries sweetalert2 and
+  wp-i18n, so it lands well after the page is interactive — later still on a site
+  serving unminified core scripts. A click before then hits a live, visible,
+  enabled button and does nothing, which surfaces as whatever the test was waiting
+  on timing out, pointing anywhere but the click. `gotoSettings` and
+  `gotoApiVerify` wait for the binding; if you navigate by hand, call
+  `waitForHandlers` yourself.
+- **The settings screen sometimes stops producing animation frames.** When it
+  does, every Playwright call that waits for an element to settle
+  (`click`, `fill`, `scrollIntoViewIfNeeded`) waits forever, and the call log
+  stops at "waiting for element to be visible, enabled and stable" without ever
+  saying why. Measured on that page: `requestAnimationFrame` never fires while
+  `readyState` is `complete`, the element is visible with `pointer-events: auto`,
+  and its box is identical across samples; a reload does not clear it, and
+  `force: true` and `page.evaluate` still work. Where a spec has to click through
+  it, assert visibility and enabled state explicitly and then click with
+  `force: true` — that waives the "has it stopped moving" wait and nothing else.

--- a/e2e/api-key-verify.e2e.ts
+++ b/e2e/api-key-verify.e2e.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+import { captureConnection, ConnectionState, restoreConnection } from './helpers/connection';
+import { confirmSwal, gotoApiVerify, gotoSettings, revealApiKeyField, swalText, swalTitle } from './helpers/wp';
+
+/**
+ * Verification is destructive by design — the submitted key is stored before it
+ * is checked, and storing it clears the assistant, inbox and knowledge base. So
+ * both tests hand the site back the way they found it.
+ */
+let saved: ConnectionState;
+
+// Restoring means verifying twice over and saving the form, each step waiting on
+// a live API round-trip — comfortably past the default per-test budget.
+test.describe.configure({ timeout: 150_000 });
+
+test.beforeEach(async ({ page }) => {
+	saved = await captureConnection(page);
+});
+
+test.afterEach(async ({ page }) => {
+	await restoreConnection(page, saved);
+});
+
+test('rejects a key the API does not recognise', async ({ page }) => {
+	await gotoApiVerify(page);
+	await page.fill('#td_helpdesk_api_key', 'this-is-not-a-thrivedesk-api-key');
+	await page.locator('#submit-btn').click();
+
+	await expect(swalTitle(page)).toHaveText('Error');
+	await expect(swalText(page)).toContainText('401');
+	await confirmSwal(page);
+
+	// With no verified key on file the menu page drops back to the welcome
+	// screen instead of the settings form.
+	await page.goto('/wp-admin/admin.php?page=thrivedesk');
+	await expect(page.locator('#td_helpdesk_form')).toHaveCount(0);
+	await expect(page.getByText("Welcome, Let's Setup Your HelpDesk")).toBeVisible();
+});
+
+test('verifies the stored key and unlocks the connected settings', async ({ page }) => {
+	await gotoSettings(page);
+	await revealApiKeyField(page);
+	await page.locator('#td-api-verification-btn').click();
+
+	await expect(swalTitle(page)).toHaveText('Success');
+
+	const verifyButton = page.locator('#td-api-verification-btn');
+	await expect(verifyButton).toHaveText('Verified');
+	await expect(verifyButton).toBeDisabled();
+
+	// Verifying is what releases the two selects the rest of the form depends on.
+	await expect(page.locator('#td-assistants')).toBeEnabled();
+
+	await confirmSwal(page);
+});

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,38 @@
+import { expect, Page, test as setup } from '@playwright/test';
+
+import {
+	ADMIN_PASSWORD,
+	ADMIN_STATE,
+	ADMIN_USER,
+	CUSTOMER_PASSWORD,
+	CUSTOMER_STATE,
+	CUSTOMER_USER,
+} from './helpers/env';
+
+async function logIn(page: Page, user: string, password: string, statePath: string): Promise<void> {
+	await page.goto('/wp-login.php');
+	await page.fill('#user_login', user);
+	await page.fill('#user_pass', password);
+	await page.click('#wp-submit');
+
+	// A wrong password re-renders wp-login.php with #login_error and no auth
+	// cookie, so assert on the cookie rather than on wherever WordPress chose to
+	// redirect — that lands on the dashboard for an admin and My Account for a
+	// customer, and themes move both.
+	await page.waitForURL((url) => !url.pathname.endsWith('/wp-login.php'));
+
+	const cookies = await page.context().cookies();
+	const authenticated = cookies.some((cookie) => cookie.name.startsWith('wordpress_logged_in_'));
+
+	expect(authenticated, `${user} did not get a WordPress auth cookie — check the credentials`).toBe(true);
+
+	await page.context().storageState({ path: statePath });
+}
+
+setup('authenticate as administrator', async ({ page }) => {
+	await logIn(page, ADMIN_USER(), ADMIN_PASSWORD(), ADMIN_STATE);
+});
+
+setup('authenticate as customer', async ({ page }) => {
+	await logIn(page, CUSTOMER_USER(), CUSTOMER_PASSWORD(), CUSTOMER_STATE);
+});

--- a/e2e/clear-cache.e2e.ts
+++ b/e2e/clear-cache.e2e.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+import { confirmSwal, gotoSettings, swalText, swalTitle } from './helpers/wp';
+
+test('clears the portal cache from the settings screen', async ({ page }) => {
+	await gotoSettings(page);
+
+	const button = page.locator('#thrivedesk_clear_cache_btn');
+
+	// The button only renders for accounts entitled to the WP Portal.
+	test.skip((await button.count()) === 0, 'the account under test has no portal access');
+
+	await button.click();
+
+	await expect(swalTitle(page)).toHaveText('Success');
+	await expect(swalText(page)).toHaveText('Cache Cleared');
+
+	// Confirming reloads the settings screen.
+	await confirmSwal(page);
+	await expect(page.locator('#td_helpdesk_form')).toBeVisible();
+});

--- a/e2e/helpdesk-form-save.e2e.ts
+++ b/e2e/helpdesk-form-save.e2e.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+import { confirmSwal, gotoSettings, swalTitle } from './helpers/wp';
+
+/**
+ * td_save_helpdesk_form() replaces the whole settings option rather than merging
+ * into it, so "the value survived a reload" is the only assertion that proves a
+ * save actually landed.
+ */
+test('saves the selected assistant and reads it back', async ({ page }) => {
+	await gotoSettings(page);
+
+	const assistants = page.locator('#td-assistants');
+	const original = await assistants.inputValue();
+
+	const target = await assistants
+		.locator('option')
+		.nth(1)
+		.getAttribute('value');
+
+	expect(target, 'the site under test has no assistant to select').toBeTruthy();
+
+	await assistants.selectOption(target!);
+	await page.locator('#td_setting_btn_submit').click();
+
+	await expect(swalTitle(page)).toHaveText('Success');
+	await confirmSwal(page);
+
+	await gotoSettings(page);
+	await expect(page.locator('#td-assistants')).toHaveValue(target!);
+
+	await page.locator('#td-assistants').selectOption(original);
+	await page.locator('#td_setting_btn_submit').click();
+	await expect(swalTitle(page)).toHaveText('Success');
+	await confirmSwal(page);
+
+	await gotoSettings(page);
+	await expect(page.locator('#td-assistants')).toHaveValue(original);
+});

--- a/e2e/helpers/connection.ts
+++ b/e2e/helpers/connection.ts
@@ -1,0 +1,143 @@
+import { expect, Page } from '@playwright/test';
+
+import { API_VERIFY_URL, gotoSettings, readStoredApiKey } from './wp';
+
+/**
+ * Everything the settings form owns. td_save_helpdesk_form() replaces the whole
+ * td_helpdesk_settings option with what the form posted, and a verification run
+ * additionally clears the assistant, inbox and knowledge base — so anything a
+ * test disturbs has to be captured up front and posted back in one save.
+ */
+export interface ConnectionState {
+	apiKey: string;
+	assistantId: string;
+	inboxId: string;
+	knowledgebaseSlug: string;
+	ticketPageId: string;
+	excludedRoutes: string[];
+	postTypes: string[];
+	postSync: string[];
+	userAccountPages: string[];
+}
+
+interface AjaxHandle {
+	url: string;
+	nonce: string;
+}
+
+declare global {
+	interface Window {
+		thrivedesk?: { ajax_url: string; nonce: string };
+	}
+}
+
+async function selectValue(page: Page, selector: string): Promise<string> {
+	const select = page.locator(selector);
+
+	return (await select.count()) > 0 ? select.inputValue() : '';
+}
+
+async function checkedValues(page: Page, selector: string): Promise<string[]> {
+	return page
+		.locator(`${selector}:checked`)
+		.evaluateAll((boxes) => boxes.map((box) => (box as HTMLInputElement).value));
+}
+
+export async function captureConnection(page: Page): Promise<ConnectionState> {
+	await gotoSettings(page);
+
+	return {
+		apiKey: await readStoredApiKey(page),
+		assistantId: await selectValue(page, '#td-assistants'),
+		inboxId: await selectValue(page, '#td-inboxes'),
+		knowledgebaseSlug: await selectValue(page, '#td_knowledgebase_slug'),
+		ticketPageId: await selectValue(page, '#td_helpdesk_page_id'),
+		excludedRoutes: await page
+			.locator('#td-excluded-routes option:checked')
+			.evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value)),
+		postTypes: await checkedValues(page, '.td_helpdesk_post_types'),
+		postSync: await checkedValues(page, '.td_helpdesk_post_sync'),
+		userAccountPages: await checkedValues(page, '.td_user_account_pages'),
+	};
+}
+
+/** The ajax url and nonce the plugin hands its own admin scripts. */
+async function ajaxHandle(page: Page): Promise<AjaxHandle> {
+	const handle = await page.evaluate(() => window.thrivedesk ?? null);
+
+	expect(handle, 'thrivedesk was not localized — is this a plugin admin screen?').not.toBeNull();
+
+	return { url: handle!.ajax_url, nonce: handle!.nonce };
+}
+
+function formBody(action: string, handle: AjaxHandle, data: Record<string, string | string[]>): string {
+	const body = new URLSearchParams();
+	body.set('action', action);
+	body.set('nonce', handle.nonce);
+
+	for (const [key, value] of Object.entries(data)) {
+		if (Array.isArray(value)) {
+			value.forEach((item) => body.append(`data[${key}][]`, item));
+		} else {
+			body.set(`data[${key}]`, value);
+		}
+	}
+
+	return body.toString();
+}
+
+async function postAjax(
+	page: Page,
+	action: string,
+	handle: AjaxHandle,
+	data: Record<string, string | string[]>,
+): Promise<string> {
+	const response = await page.request.post(handle.url, {
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		data: formBody(action, handle, data),
+	});
+
+	expect(response.ok(), `${action} returned ${response.status()}`).toBe(true);
+
+	return response.text();
+}
+
+/**
+ * Puts the connection back the way captureConnection() found it.
+ *
+ * Teardown goes through the plugin's own admin-ajax actions — the very ones the
+ * settings screen posts — rather than by clicking through the form again. Two
+ * requests replace a dozen interactions, and it keeps teardown out of the way of
+ * how the admin page renders: the screen reached through the onboarding
+ * verification flow stops producing animation frames, which is enough to stall
+ * every Playwright action that waits for an element to settle.
+ */
+export async function restoreConnection(page: Page, state: ConnectionState): Promise<void> {
+	// The API-verify screen renders whatever state the connection is in, so it is
+	// the one plugin page guaranteed to be there — and to carry the ajax handle.
+	await page.goto(API_VERIFY_URL);
+
+	const handle = await ajaxHandle(page);
+
+	// Stores the key alongside every other setting in one save.
+	const saved = await postAjax(page, 'thrivedesk_helpdesk_form', handle, {
+		td_helpdesk_api_key: state.apiKey,
+		td_helpdesk_assistant: state.assistantId,
+		td_helpdesk_inbox_id: state.inboxId,
+		td_knowledgebase_slug: state.knowledgebaseSlug,
+		td_helpdesk_page_id: state.ticketPageId,
+		td_assistant_route_list: state.excludedRoutes,
+		td_helpdesk_post_types: state.postTypes,
+		td_helpdesk_post_sync: state.postSync,
+		td_user_account_pages: state.userAccountPages,
+	});
+
+	expect(saved, 'restoring the settings failed').toContain('success');
+
+	// Re-fetches the account's system info, which also marks the key verified.
+	const info = await postAjax(page, 'thrivedesk_system_info', handle, {
+		td_helpdesk_api_key: state.apiKey,
+	});
+
+	expect(info, 'restoring the system info failed').toContain('"status":"true"');
+}

--- a/e2e/helpers/env.ts
+++ b/e2e/helpers/env.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+
+export const ADMIN_STATE = path.join(__dirname, '..', '.auth', 'admin.json');
+export const CUSTOMER_STATE = path.join(__dirname, '..', '.auth', 'customer.json');
+
+/**
+ * Every credential and URL comes from the environment so the suite can point at
+ * any WordPress running the plugin. Missing values throw at config load instead
+ * of surfacing as a login that silently redirects back to wp-login.php.
+ */
+export function requireEnv(name: string): string {
+	const value = process.env[name];
+
+	if (!value) {
+		throw new Error(`${name} is not set — see e2e/README.md for the variables the suite needs`);
+	}
+
+	return value;
+}
+
+export const ADMIN_USER = () => requireEnv('WP_ADMIN_USER');
+export const ADMIN_PASSWORD = () => requireEnv('WP_ADMIN_PASSWORD');
+export const CUSTOMER_USER = () => requireEnv('WP_CUSTOMER_USER');
+export const CUSTOMER_PASSWORD = () => requireEnv('WP_CUSTOMER_PASSWORD');
+
+/** Path of a published page carrying the [thrivedesk_portal] shortcode. */
+export const PORTAL_PATH = () => process.env['WP_PORTAL_PATH'] ?? '/thrivedesk-support-portal/';
+
+/**
+ * The portal page is reached by a pretty permalink on some sites and by
+ * `/?page_id=N` on others, so query parameters have to be joined with whichever
+ * separator the configured path leaves free.
+ */
+export function portalUrl(query = ''): string {
+	const path = PORTAL_PATH();
+
+	if (!query) {
+		return path;
+	}
+
+	return `${path}${path.includes('?') ? '&' : '?'}${query}`;
+}

--- a/e2e/helpers/wp.ts
+++ b/e2e/helpers/wp.ts
@@ -1,0 +1,95 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export const SETTINGS_URL = '/wp-admin/admin.php?page=thrivedesk';
+export const API_VERIFY_URL = '/wp-admin/admin.php?page=td-api';
+
+/**
+ * The ThriveDesk menu page renders one of three views depending on stored state
+ * (welcome / api-verify / settings). Landing on the wrong one means the site
+ * under test isn't connected, so say that rather than time out on a selector.
+ */
+export async function gotoSettings(page: Page): Promise<void> {
+	await page.goto(SETTINGS_URL);
+
+	const form = page.locator('#td_helpdesk_form');
+
+	if ((await form.count()) === 0) {
+		throw new Error(
+			'The ThriveDesk settings form did not render — the site under test must be connected to a ThriveDesk account before running the suite (see e2e/README.md)',
+		);
+	}
+
+	await expect(form).toBeVisible();
+	await waitForHandlers(page, 'button.connect');
+}
+
+export async function gotoApiVerify(page: Page): Promise<void> {
+	await page.goto(API_VERIFY_URL);
+	await expect(page.locator('#submit-btn')).toBeVisible();
+	await waitForHandlers(page, '#submit-btn');
+}
+
+/**
+ * Waits until the plugin's admin script has bound its click handlers.
+ *
+ * Rendered markup is not a ready button here: every handler is registered inside
+ * one jQuery ready callback in admin.js, and that bundle carries sweetalert2 and
+ * wp-i18n, so it lands well after the page is interactive — later still on a site
+ * serving unminified core scripts. A click before then hits a live, visible,
+ * enabled button and does absolutely nothing, which surfaces much later as
+ * whatever the test was waiting on timing out.
+ *
+ * Checking one bound element is enough: the callback binds them all at once.
+ */
+export async function waitForHandlers(page: Page, selector: string): Promise<void> {
+	await page.waitForFunction((sel) => {
+		// Minimal shape of what this needs from jQuery; the plugin ships no types.
+		type Bound = ((s: string) => ArrayLike<Element>) & {
+			_data: (el: Element, key: string) => { click?: unknown } | undefined;
+		};
+
+		const jq = (window as unknown as { jQuery?: Bound }).jQuery;
+		if (!jq) {
+			return false;
+		}
+		const el = jq(sel)[0];
+
+		return !!el && !!jq._data(el, 'events')?.click;
+	}, selector);
+}
+
+/** The stored key, read off the settings form. Hidden until "Update" is clicked. */
+export async function readStoredApiKey(page: Page): Promise<string> {
+	const key = await page.locator('#td_helpdesk_api_key').inputValue();
+
+	expect(key, 'the site under test has no stored API key').not.toBe('');
+
+	return key;
+}
+
+/** Reveals the API key field on the settings page so it can be edited. */
+export async function revealApiKeyField(page: Page): Promise<void> {
+	await page.locator('.api-key-preview .trigger').click();
+	await expect(page.locator('#td_helpdesk_api_key')).toBeVisible();
+}
+
+export function swalTitle(page: Page): Locator {
+	return page.locator('.swal2-title');
+}
+
+export function swalText(page: Page): Locator {
+	return page.locator('.swal2-html-container');
+}
+
+export async function confirmSwal(page: Page): Promise<void> {
+	await page.locator('.swal2-confirm').click();
+}
+
+/**
+ * Portal rendering is entitlement-gated: an account whose plan doesn't include
+ * the WP Portal gets a notice in place of the ticket list. Tests that need the
+ * list skip themselves rather than fail on an environment they can't fix.
+ */
+export async function portalIsEntitled(page: Page): Promise<boolean> {
+	return (await page.locator('.td-portal-notice').count()) === 0;
+}

--- a/e2e/portal-anonymous.e2e.ts
+++ b/e2e/portal-anonymous.e2e.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+import { PORTAL_PATH } from './helpers/env';
+
+test('sends a signed-out visitor to the login form instead of a ticket list', async ({ page }) => {
+	await page.goto(PORTAL_PATH());
+
+	await expect(page.getByText('You must be logged in to view the ticket or conversation')).toBeVisible();
+	await expect(page.locator('#conversation-table')).toHaveCount(0);
+
+	const login = page.getByRole('link', { name: 'here' });
+	await expect(login).toHaveAttribute('href', /wp-login\.php/);
+});

--- a/e2e/portal-customer-scope.e2e.ts
+++ b/e2e/portal-customer-scope.e2e.ts
@@ -1,0 +1,58 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { portalUrl } from './helpers/env';
+import { portalIsEntitled } from './helpers/wp';
+
+const TICKET_ROWS = '#conversation-table tbody tr[data-ticket-id]';
+
+async function ticketIds(page: Page): Promise<string[]> {
+	return page.locator(TICKET_ROWS).evaluateAll((rows) =>
+		rows.map((row) => row.getAttribute('data-ticket-id') ?? ''),
+	);
+}
+
+test('shows the signed-in customer their own tickets', async ({ page }) => {
+	await page.goto(portalUrl());
+
+	test.skip(!(await portalIsEntitled(page)), 'the account under test has no portal access');
+
+	await expect(page.locator('#conversation-table')).toBeVisible();
+	expect((await ticketIds(page)).length, 'the customer under test has no tickets to list').toBeGreaterThan(0);
+});
+
+/**
+ * Regression guard for the portal ticket list being scoped to whoever is asking.
+ *
+ * cv_page used to reach the request URL unsanitised, so a logged-in customer
+ * could append a second customer_email to it and read another customer's list —
+ * the API takes the last value of a duplicated parameter. absint() on the page
+ * plus http_build_query() on the whole query closes that.
+ *
+ * The injected load has to come first. Before the fix the raw cv_page also went
+ * into the cache key, so the poisoned request always missed the cache and hit
+ * the API; a clean load beforehand would not mask it, but ordering it this way
+ * keeps the failure immediate and obvious.
+ */
+test('ignores a customer_email smuggled in through cv_page', async ({ page }) => {
+	const injected = portalUrl(`cv_page=${encodeURIComponent('1&customer_email=someone.else@example.com')}`);
+
+	await page.goto(injected);
+
+	// Guard the guard: if the parameter never lands in $_GET there is nothing to
+	// smuggle and the assertions below would pass against vulnerable code.
+	expect(new URL(page.url()).searchParams.get('cv_page')).toBe('1&customer_email=someone.else@example.com');
+
+	test.skip(!(await portalIsEntitled(page)), 'the account under test has no portal access');
+
+	// A successful injection asks ThriveDesk for a contact this customer has
+	// nothing to do with; the list comes back empty and the table is replaced
+	// by the empty state.
+	await expect(page.locator('#conversation-table')).toBeVisible();
+
+	const smuggled = await ticketIds(page);
+
+	await page.goto(portalUrl());
+	const own = await ticketIds(page);
+
+	expect(smuggled).toEqual(own);
+});

--- a/e2e/settings-page.e2e.ts
+++ b/e2e/settings-page.e2e.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+import { gotoSettings } from './helpers/wp';
+
+/**
+ * The assistant and inbox lists are rendered server-side from live API calls, so
+ * an empty list here means the round-trip to ThriveDesk is broken — not that a
+ * template changed. That makes this the cheapest signal that the connection
+ * actually works, as opposed to merely being flagged as verified.
+ */
+test('lists the assistants and inboxes fetched from ThriveDesk', async ({ page }) => {
+	await gotoSettings(page);
+
+	const assistants = page.locator('#td-assistants option');
+	await expect(assistants.first()).toHaveText(/Select an assistant/);
+	expect(await assistants.count(), 'no assistants came back from the API').toBeGreaterThan(1);
+
+	const inboxes = page.locator('#td-inboxes option');
+	expect(await inboxes.count(), 'no inboxes came back from the API').toBeGreaterThan(1);
+});
+
+test('offers every integration the plugin supports', async ({ page }) => {
+	await gotoSettings(page);
+
+	const woocommerce = page.locator('button.connect[data-plugin="woocommerce"]');
+	await expect(woocommerce).toBeVisible();
+
+	// WooCommerce is active on the site under test, so its button must be live.
+	// The inactive integrations render disabled with a "Not installed" hint.
+	await expect(woocommerce).toBeEnabled();
+
+	for (const plugin of ['edd', 'fluentcrm', 'wppostsync', 'autonami']) {
+		await expect(page.locator(`button.connect[data-plugin="${plugin}"]`)).toHaveCount(1);
+	}
+});

--- a/e2e/woocommerce-connect.e2e.ts
+++ b/e2e/woocommerce-connect.e2e.ts
@@ -1,0 +1,122 @@
+import { expect, Locator, Page, test } from '@playwright/test';
+
+import { gotoSettings } from './helpers/wp';
+
+interface ConnectPayload {
+	store_url: string;
+	api_token: string;
+	org_id: string;
+	cancel_url: string;
+	success_url: string;
+}
+
+/**
+ * Returns the integration's button with the integration disconnected, whatever
+ * state it was in.
+ *
+ * The same button is Connect or Disconnect depending on stored state, and each
+ * posts a different action — so a spec that assumes one of them silently drives
+ * the other. Seeded sites can arrive either way (the WooCommerce demo seed marks
+ * it connected), and connecting is what these specs are about, so normalise here
+ * rather than depending on how the site was left.
+ */
+async function disconnected(page: Page, plugin: string): Promise<Locator> {
+	await gotoSettings(page);
+
+	const button = page.locator(`button.connect[data-plugin="${plugin}"]`);
+	await expect(button).toBeVisible();
+	await expect(button).toBeEnabled();
+
+	if ((await button.getAttribute('data-connected')) === '1') {
+		// The disconnect path confirms through a native alert, then reloads.
+		page.once('dialog', (dialog) => dialog.accept());
+		await Promise.all([
+			page.waitForResponse(
+				(candidate) =>
+					candidate.url().includes('admin-ajax.php') &&
+					(candidate.request().postData() ?? '').includes('action=thrivedesk_disconnect_plugin'),
+			),
+			button.click(),
+		]);
+
+		await gotoSettings(page);
+		await expect(button).toHaveAttribute('data-connected', '0');
+	}
+
+	return button;
+}
+
+/**
+ * Clicks Connect and decodes the payload the plugin hands back.
+ *
+ * Read from the ajax response, which IS the redirect URL the plugin built, not
+ * from the navigation that follows it. The navigation leaves for the ThriveDesk
+ * app — a single-page app that may not even be served wherever this suite is
+ * pointed, and which routes away and drops the query when it is. What belongs to
+ * WordPress is the URL it produced, and that is what this asserts.
+ */
+async function connectPayload(page: Page, plugin: string): Promise<ConnectPayload> {
+	const button = await disconnected(page, plugin);
+
+	const [response] = await Promise.all([
+		page.waitForResponse(
+			(candidate) =>
+				candidate.url().includes('admin-ajax.php') &&
+				(candidate.request().postData() ?? '').includes('action=thrivedesk_connect_plugin'),
+		),
+		button.click(),
+	]);
+
+	expect(response.status(), 'the connect action did not return 200').toBe(200);
+
+	// Read the body before anything navigates: the response resource belongs to
+	// the current document and is discarded the moment one is attempted.
+	const redirect = (await response.text()).trim();
+
+	// Then wait for the hand-off to be attempted (and refused, see beforeEach)
+	// before handing control back. A navigation still pending here would abort
+	// whatever this page is asked to do next.
+	await page.waitForRequest((candidate) => candidate.url().includes(`/apps/${plugin}?connect=`));
+
+	const connect = new URL(redirect).searchParams.get('connect') ?? '';
+	expect(connect, `no connect param in the redirect the plugin built: ${redirect}`).not.toBe('');
+
+	return JSON.parse(Buffer.from(connect, 'base64').toString('utf8')) as ConnectPayload;
+}
+
+test.beforeEach(async ({ page }) => {
+	// Three quarters of a second after the ajax call the plugin sends the browser
+	// to ThriveDesk. Refuse the hand-off: the contract under test is the URL
+	// WordPress built, and following it would depend on an app that isn't
+	// necessarily served wherever this suite runs. An aborted navigation leaves
+	// the settings screen exactly where it is.
+	await page.route('**/apps/**', (route) => route.abort());
+});
+
+/**
+ * Connecting an integration hands ThriveDesk a base64 payload in the URL and
+ * lets the app take it from there. Both sides parse that payload, so its shape
+ * is a contract — this asserts the WordPress half of it.
+ */
+test('hands ThriveDesk a connect payload for WooCommerce', async ({ page, baseURL }) => {
+	const payload = await connectPayload(page, 'woocommerce');
+
+	// get_bloginfo('url') — the site's own address, which is what ThriveDesk
+	// stores as the store it calls back into.
+	expect(payload.store_url).toBe(baseURL?.replace(/\/$/, ''));
+	expect(payload.org_id).not.toBe('');
+
+	// 32 random bytes, hex-encoded. This token is the HMAC key for the inbound
+	// listener, so anything shorter or guessable is a security regression.
+	expect(payload.api_token).toMatch(/^[0-9a-f]{64}$/);
+
+	expect(payload.success_url).toContain('td-activated=true');
+	expect(payload.cancel_url).toContain('td-activated=false');
+});
+
+test('issues a fresh token on every connect attempt', async ({ page }) => {
+	const first = await connectPayload(page, 'woocommerce');
+	const second = await connectPayload(page, 'woocommerce');
+
+	expect(first.api_token).not.toBe(second.api_token);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
 	"name": "thrivedesk",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "thrivedesk",
-			"version": "2.5.0",
+			"version": "2.6.0",
 			"license": "ISC",
 			"dependencies": {
 				"sweetalert2": "^11.4.8"
 			},
 			"devDependencies": {
+				"@playwright/test": "1.61.1",
 				"@tailwindcss/postcss": "^4.0.0",
 				"@tailwindcss/typography": "^0.5.15",
 				"@wordpress/scripts": "^32.0.0",
@@ -4523,7 +4524,6 @@
 			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.61.1"
 			},
@@ -19941,7 +19941,6 @@
 			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.61.1"
 			},
@@ -19961,7 +19960,6 @@
 			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -19980,7 +19978,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"watch:wp-scripts": "wp-scripts start resources/js/wp-scripts/thrivedesk-autonami-tab.js --output-path=assets/js/wp-scripts",
 		"build:wp-scripts": "wp-scripts build resources/js/wp-scripts/thrivedesk-autonami-tab.js --output-path=assets/js/wp-scripts",
 		"build": "npm run production && npm run build:wp-scripts",
+		"e2e": "playwright test",
+		"e2e:ui": "playwright test --ui",
 		"release": "scripts/release.sh"
 	},
 	"repository": {
@@ -24,6 +26,7 @@
 	},
 	"homepage": "https://github.com/thrivedesk/wp-thrivedesk#readme",
 	"devDependencies": {
+		"@playwright/test": "1.61.1",
 		"@tailwindcss/postcss": "^4.0.0",
 		"@tailwindcss/typography": "^0.5.15",
 		"@wordpress/scripts": "^32.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,58 @@
+import { defineConfig, devices } from '@playwright/test';
+
+import { ADMIN_STATE, CUSTOMER_STATE, requireEnv } from './e2e/helpers/env';
+
+/**
+ * The suite drives a real WordPress with this plugin active — there is no
+ * fixture site to fall back to, so a missing WP_BASE_URL is a hard stop
+ * rather than a silent default that fails later with a confusing 404.
+ */
+const baseURL = requireEnv('WP_BASE_URL');
+
+export default defineConfig({
+	testDir: './e2e',
+	testMatch: ['**/*.e2e.ts'],
+	forbidOnly: !!process.env['CI'],
+	retries: process.env['CI'] ? 2 : 0,
+
+	/* Serial, always. The tests drive one shared WordPress and several of them
+	 * write site-wide options (thrivedesk_options on connect, td_helpdesk_settings
+	 * on save). Parallel workers would interleave those writes against the same
+	 * rows and the restore in one test would land on top of another's edit. */
+	workers: 1,
+
+	reporter: [['list'], ['html', { open: 'never' }]],
+
+	use: {
+		baseURL,
+		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		/* Dev and staging sites are commonly fronted by a private CA. */
+		ignoreHTTPSErrors: true,
+	},
+
+	/* Portal first, admin last. Re-verifying an API key clears the cached portal
+	 * entitlement, and an account whose plan is read straight from ThriveDesk
+	 * gets it straight back — but one relying on the cached answer would not,
+	 * and the portal tests would skip for the rest of the run. */
+	projects: [
+		{ name: 'setup', testMatch: /auth\.setup\.ts/ },
+		{
+			name: 'anonymous',
+			use: { ...devices['Desktop Chrome'], storageState: { cookies: [], origins: [] } },
+			testMatch: /portal-anonymous\.e2e\.ts/,
+		},
+		{
+			name: 'customer',
+			use: { ...devices['Desktop Chrome'], storageState: CUSTOMER_STATE },
+			dependencies: ['setup'],
+			testMatch: /portal-customer-scope\.e2e\.ts/,
+		},
+		{
+			name: 'admin',
+			use: { ...devices['Desktop Chrome'], storageState: ADMIN_STATE },
+			dependencies: ['setup'],
+			testIgnore: /portal-.*\.e2e\.ts/,
+		},
+	],
+});


### PR DESCRIPTION
### 📉 The Problem
The plugin previously had no browser coverage. While we had 172 PHPUnit tests and PHPCS, there were zero tests that actually loaded `wp-admin`, clicked **Connect**, or rendered the portal shortcode.

---

### 🚀 The Solution: E2E Test Suite
Added 13 new E2E tests across 7 spec files and 4 role projects. 

**Coverage includes:**
* **API Key Verification:** Tests for both accepted and rejected keys.
* **Settings Screen:** Ensures assistants and inboxes fetched from the live API render correctly.
* **WooCommerce Connect:** Validates the payload and its token entropy.
* **Helpdesk Form:** Full round-trip testing.
* **Portal Cache:** Verifies portal cache clearing functionality.
* **Portal Customer Scoping:** Acts as a regression guard for the `cv_page` injection fixed in **#199** *(verified this by reverting the fix and watching the test fail)*.

---

### ⚙️ Configuration & Deployment
* **Environment Agnostic:** Configured entirely from environment variables, allowing the suite to point at *any* WordPress instance running the plugin.
* **Documentation:** See `e2e/README.md` for required variables and preconditions.
* **Distribution:** This test suite is excluded from the release build and does not ship to `wp.org`.