### PR TITLE
fix(listener): verify only the signed contract params, not raw $_REQUEST

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** WooCommerce Extension Changelog ***
 
-2026-07-27 - version 2.6.0
+2026-08-06 - version 2.6.0
+* fix: Connecting a store, and loading customer and order details inside a conversation, keep working when another plugin on the site adds its own parameters to the page URL. Product filter plugins such as HUSKY/WOOF, along with caching, analytics, or multilingual plugins, previously made the store reject these requests as unauthorized.
 * fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
 * fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
 * fix: A ticket's messages are cached per customer, so a ticket someone else just opened is no longer shown to whoever asks for it by id. Sending a reply clears only your own cached copy instead of every customer's.

--- a/readme.md
+++ b/readme.md
@@ -375,7 +375,8 @@ Setup takes under 5 minutes. No coding required.
 == Changelog ==
 
 = 2.6.0 =
-2026-07-27 - version 2.6.0
+2026-08-06 - version 2.6.0
+* fix: Connecting a store, and loading customer and order details inside a conversation, keep working when another plugin on the site adds its own parameters to the page URL. Product filter plugins such as HUSKY/WOOF, along with caching, analytics, or multilingual plugins, previously made the store reject these requests as unauthorized.
 * fix: The customer portal's ticket list is scoped to the customer viewing it. A crafted page link could previously make the site ask ThriveDesk for someone else's tickets and show them to whoever was logged in.
 * fix: Replying from the portal checks the ticket id before contacting ThriveDesk, so a crafted id can no longer point that request somewhere else.
 * fix: A ticket's messages are cached per customer, so a ticket someone else just opened is no longer shown to whoever asks for it by id. Sending a reply clears only your own cached copy instead of every customer's.

--- a/src/Api.php
+++ b/src/Api.php
@@ -13,6 +13,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class Api {
 	/**
+	 * Request parameters that make up the signed inbound contract, across every
+	 * integration (EDD, WooCommerce, FluentCRM, Autonami, WPPostSync). The SaaS
+	 * signs an HMAC over exactly the params it sends; verify_token() hashes only
+	 * these, so a store plugin that injects its own query var into the request
+	 * (WOOF's woof_parse_query, a cache-buster, utm_*, a multilingual lang) can't
+	 * alter the signature. Keep in step with the signers in
+	 * app/apps/<Integration>/Services/*Service.php.
+	 *
+	 * @var string[]
+	 */
+	private const SIGNED_PARAMS = [
+		'listener',
+		'plugin',
+		'action',
+		'email',
+		'shipping_param',
+		'order_id',
+		'order_status',
+		'item',
+		'item_id',
+		'quantity',
+		'coupon',
+		'amount',
+		'reason',
+		'subscription_status',
+		'order_types',
+		'sync_type',
+		'extra',
+		'query',
+	];
+
+	/**
 	 * The single instance of this class
 	 */
 	private static $instance = null;
@@ -569,7 +601,13 @@ final class Api {
 	 * @since 0.0.4
 	 */
 	private function verify_token(): bool {
-		$payload = $_REQUEST;
+		// Hash only the contract params, never the raw $_REQUEST: a third-party
+		// plugin on the store can add its own query var to every request (this hit
+		// a customer whose WOOF plugin injected woof_parse_query), and folding that
+		// into the HMAC breaks the signature the SaaS computed over the contract
+		// alone. The superglobals are left untouched, so the dispatcher below still
+		// reads the real values.
+		$payload = array_intersect_key( $_REQUEST, array_flip( self::SIGNED_PARAMS ) );
 
 		if ( $payload ) {
 			foreach ( $payload as $key => $value ) {

--- a/tests/HmacSignatureTest.php
+++ b/tests/HmacSignatureTest.php
@@ -105,6 +105,36 @@ class HmacSignatureTest extends TD_Ajax_TestCase {
 		$this->assertSame( 'Request unauthorized', $body['message'] );
 	}
 
+	public function test_foreign_request_params_are_ignored() {
+		// A store plugin can add its own query var to every front-end request,
+		// including our ?listener= endpoint. HUSKY/WOOF's woof_parse_query is the
+		// real-world case: it broke both connect and the conversation widget's
+		// data calls on a customer store; utm_/lang stand in for the rest
+		// (cache-busters, analytics, multilingual). verify_token() runs the same
+		// for every action (connect and every widget/data call alike), so filtering
+		// on the connect payload here covers all of them: the SaaS signs only the
+		// contract params, so verify_token() must hash only those and ignore
+		// anything else in $_REQUEST, or the signature never matches.
+		$signed    = [
+			'listener' => 'thrivedesk',
+			'plugin'   => 'edd',
+			'action'   => 'connect',
+		];
+		$signature = td_test_sign_payload( $signed, self::TOKEN );
+
+		$received = array_merge(
+			$signed,
+			[
+				'woof_parse_query' => '1',
+				'utm_source'       => 'newsletter',
+				'lang'             => 'en',
+			]
+		);
+		$body = $this->dispatch( $received, $signature );
+
+		$this->assertSame( 'Site connected successfully', $body['message'] );
+	}
+
 	public function test_data_action_requires_connected_integration() {
 		// After the admin starts connect the token exists but 'connected' stays
 		// false until the SaaS calls back. In that window only connect/disconnect


### PR DESCRIPTION
### 🐛 The Bug
`verify_token()` HMAC'd the entire `$_REQUEST`. Because of this, any plugin that injects a query var into front-end requests changed the hashed payload and made the SaaS-signed request fail with a `401 Request unauthorized` error. 

**Known Triggers:**
* HUSKY/WOOF's `woof_parse_query`
* Cache busters
* `utm_*` tracking tags
* Multilingual `lang` parameters

**Impact:** This broke both connecting a store and the conversation widget's customer/order lookups on affected sites.

---

### 🛠️ The Fix
Hash only the known contract keys:

```php
array_intersect_key($_REQUEST, array_flip(SIGNED_PARAMS))

```

`SIGNED_PARAMS` is the union of every integration's signed params (EDD, WooCommerce, FluentCRM, Autonami, WPPostSync). Injected request vars are now dropped before the HMAC.

**Technical Notes:**

* **Plugin-only & Backward Compatible:** The SaaS signs a subset of the allowlist, so clean payloads hash identically.
* **Superglobals Untouched:** The global state is left untouched, ensuring the dispatcher still reads the real values.

---

### 🧪 Scope & Testing

* **Scope:** Covers connect and every widget/data call (`verify_token` does not branch on action).
* **Automated Tests:** `HmacSignatureTest::test_foreign_request_params_are_ignored` reproduces the WOOF/HUSKY case (red before, green after).